### PR TITLE
Fix operator task list DOM references

### DIFF
--- a/js/operatorTasksPage.js
+++ b/js/operatorTasksPage.js
@@ -1,16 +1,27 @@
 // js/operatorTasksPage.js
-import { showPage } from './ui.js'; // uiElements for DOM, showPage for navigation
+import { showPage } from './ui.js'; // for navigation if needed
 import { database } from './config.js';        // Firebase database service
 import { ref, query, orderByChild, equalTo, get } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-database.js";
 import { showAppStatus } from './utils.js';
 import { getCurrentUserRole } from './auth.js';
 
+// DOM elements scoped within this module
+let refreshTaskListButton,
+    operatorOrderListContainer,
+    noOperatorTasksMessage,
+    operatorTasksAppStatus;
+
 
 export function initializeOperatorTasksPageListeners() {
-    if (uiElements.refreshOperatorTaskList) {
-        uiElements.refreshOperatorTaskList.addEventListener('click', loadOperatorPendingTasks);
+    refreshTaskListButton = document.getElementById('refreshOperatorTaskList');
+    operatorOrderListContainer = document.getElementById('operatorOrderListContainer');
+    noOperatorTasksMessage = document.getElementById('noOperatorTasksMessage');
+    operatorTasksAppStatus = document.getElementById('appStatus');
+
+    if (refreshTaskListButton) {
+        refreshTaskListButton.addEventListener('click', loadOperatorPendingTasks);
     } else {
-        console.warn("Refresh button for Operator Task List not found.");
+        console.warn('Refresh button for Operator Task List not found.');
     }
     // Add other listeners if needed for this page (e.g., sorting, filtering within the list)
 }
@@ -19,20 +30,20 @@ export async function loadOperatorPendingTasks() {
     const currentUserRole = getCurrentUserRole();
     // Allow admin to also view this page
     if (currentUserRole !== 'operator' && currentUserRole !== 'administrator') {
-        showAppStatus("คุณไม่มีสิทธิ์เข้าถึงหน้านี้", "error", uiElements.appStatus);
+        showAppStatus('คุณไม่มีสิทธิ์เข้าถึงหน้านี้', 'error', operatorTasksAppStatus);
         // Consider redirecting to dashboard or login if not authorized
-        // showPage('dashboardPage'); 
+        // showPage('dashboardPage');
         return;
     }
 
-    if (!uiElements.operatorOrderListContainer || !uiElements.noOperatorTasksMessage || !uiElements.appStatus) {
+    if (!operatorOrderListContainer || !noOperatorTasksMessage || !operatorTasksAppStatus) {
         console.error("Required DOM elements for operator task list are missing.");
         return;
     }
 
-    showAppStatus("กำลังโหลดรายการออเดอร์ที่รอแพ็ก...", "info", uiElements.appStatus);
-    uiElements.operatorOrderListContainer.innerHTML = '<p style="text-align:center; padding:15px;">กำลังโหลด...</p>';
-    uiElements.noOperatorTasksMessage.classList.add('hidden');
+    showAppStatus('กำลังโหลดรายการออเดอร์ที่รอแพ็ก...', 'info', operatorTasksAppStatus);
+    operatorOrderListContainer.innerHTML = '<p style="text-align:center; padding:15px;">กำลังโหลด...</p>';
+    noOperatorTasksMessage.classList.add('hidden');
 
     try {
         const ordersRef = ref(database, 'orders');
@@ -40,7 +51,7 @@ export async function loadOperatorPendingTasks() {
         const dataQuery = query(ordersRef, orderByChild('status'), equalTo('Ready to Pack'));
         const snapshot = await get(dataQuery);
 
-        uiElements.operatorOrderListContainer.innerHTML = ''; // Clear loading message
+        operatorOrderListContainer.innerHTML = ''; // Clear loading message
 
         if (snapshot.exists()) {
             let tasksFound = 0;
@@ -63,18 +74,18 @@ export async function loadOperatorPendingTasks() {
                     <p style="font-size:0.9em; margin:3px 0;"><strong>Due Date:</strong> ${orderData.dueDate ? new Date(orderData.dueDate).toLocaleDateString('th-TH') : 'N/A'}</p>
                     <button type="button" class="start-packing-btn" data-orderkey="${orderKey}" style="width:auto; padding:8px 15px; margin-top:10px; font-size:0.9em;">เริ่มแพ็กรายการนี้</button>
                 `;
-                uiElements.operatorOrderListContainer.appendChild(orderItemDiv);
+                operatorOrderListContainer.appendChild(orderItemDiv);
             });
 
             if (tasksFound === 0) {
-                uiElements.noOperatorTasksMessage.classList.remove('hidden');
-                 showAppStatus("ไม่พบออเดอร์ที่รอแพ็กในขณะนี้", "info", uiElements.appStatus);
+                noOperatorTasksMessage.classList.remove('hidden');
+                 showAppStatus('ไม่พบออเดอร์ที่รอแพ็กในขณะนี้', 'info', operatorTasksAppStatus);
             } else {
-                 showAppStatus(`พบ ${tasksFound} ออเดอร์รอแพ็ก`, "success", uiElements.appStatus);
+                 showAppStatus(`พบ ${tasksFound} ออเดอร์รอแพ็ก`, 'success', operatorTasksAppStatus);
             }
 
             // Add event listeners to the "เริ่มแพ็กรายการนี้" buttons
-            uiElements.operatorOrderListContainer.querySelectorAll('.start-packing-btn').forEach(button => {
+            operatorOrderListContainer.querySelectorAll('.start-packing-btn').forEach(button => {
                 button.addEventListener('click', (e) => {
                     const orderKeyToPack = e.target.dataset.orderkey;
                     console.log(`Operator wants to pack order: ${orderKeyToPack}`);
@@ -83,19 +94,19 @@ export async function loadOperatorPendingTasks() {
                     if (typeof window.loadOrderForPacking === 'function') {
                         window.loadOrderForPacking(orderKeyToPack);
                     } else {
-                        console.error("loadOrderForPacking function is not available globally.");
-                        alert("เกิดข้อผิดพลาด: ไม่สามารถโหลดรายละเอียดออเดอร์ได้");
+                        console.error('loadOrderForPacking function is not available globally.');
+                        alert('เกิดข้อผิดพลาด: ไม่สามารถโหลดรายละเอียดออเดอร์ได้');
                     }
                 });
             });
 
         } else {
-            uiElements.noOperatorTasksMessage.classList.remove('hidden');
-            showAppStatus("ไม่พบออเดอร์ที่รอแพ็กในขณะนี้", "info", uiElements.appStatus);
+            noOperatorTasksMessage.classList.remove('hidden');
+            showAppStatus('ไม่พบออเดอร์ที่รอแพ็กในขณะนี้', 'info', operatorTasksAppStatus);
         }
     } catch (error) {
         console.error("Error loading operator pending tasks:", error);
-        uiElements.operatorOrderListContainer.innerHTML = '<p style="color:red; text-align:center;">เกิดข้อผิดพลาดในการโหลดรายการ</p>';
-        showAppStatus("เกิดข้อผิดพลาดในการโหลดรายการ: " + error.message, "error", uiElements.appStatus);
+        operatorOrderListContainer.innerHTML = '<p style="color:red; text-align:center;">เกิดข้อผิดพลาดในการโหลดรายการ</p>';
+        showAppStatus('เกิดข้อผิดพลาดในการโหลดรายการ: ' + error.message, 'error', operatorTasksAppStatus);
     }
 }


### PR DESCRIPTION
## Summary
- remove old `uiElements` references from `operatorTasksPage.js`
- query necessary DOM elements locally
- use local variables for status display

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684064b927988324838087c6fc80f64f