### PR TITLE
Fix header comment in operator tasks module

### DIFF
--- a/js/operatorTasksPage.js
+++ b/js/operatorTasksPage.js
@@ -1,5 +1,5 @@
 // js/operatorTasksPage.js
-import { showPage } from './ui.js'; // uiElements for DOM, showPage for navigation
+import { showPage } from './ui.js'; // showPage for navigation
 import { database } from './config.js';        // Firebase database service
 import { ref, query, orderByChild, equalTo, get } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-database.js";
 import { showAppStatus } from './utils.js';


### PR DESCRIPTION
## Summary
- remove leftover `uiElements` reference from operator tasks page import comment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684066db997c8324954f244e78206bb2