### PR TITLE
Add numeric Tiktok detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Dragon Delivery App
+
+This project provides a simple interface for managing delivery orders.
+
+## Running Tests
+
+Install dependencies and run the Jest test suite:
+
+```bash
+npm install
+npm test
+```
+
+The tests are located in the `tests` directory and verify utility functions such as `detectPlatformFromPackageCode`.

--- a/js/utils.js
+++ b/js/utils.js
@@ -20,6 +20,9 @@ export function detectPlatformFromPackageCode(packageCode) {
         // Example: J&T Express or Kerry (often used by Tiktok or other platforms)
         // You might want to differentiate further if needed
         return "Tiktok"; // Or "J&T", "Kerry"
+    } else if (/^\d{8,15}$/.test(code)) {
+        // Some Tiktok package codes are now digits only without any letters
+        return "Tiktok";
     }
     // Add more conditions for other platforms/couriers you use
     // --- End Example Platform Detection Logic ---

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "dragon-delivery-app",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1"
+  }
+}

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,17 @@
+import { detectPlatformFromPackageCode } from '../js/utils.js';
+
+test('detects Shopee from TH code', () => {
+  expect(detectPlatformFromPackageCode('TH12345678901')).toBe('Shopee');
+});
+
+test('detects Lazada from LEX code', () => {
+  expect(detectPlatformFromPackageCode('LEX4567890')).toBe('Lazada');
+});
+
+test('detects Tiktok from JT code', () => {
+  expect(detectPlatformFromPackageCode('JT123456789')).toBe('Tiktok');
+});
+
+test('detects Tiktok from digits-only code', () => {
+  expect(detectPlatformFromPackageCode('123456789012')).toBe('Tiktok');
+});


### PR DESCRIPTION
## Summary
- handle digits-only Tiktok package codes
- test utils for numeric Tiktok codes

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684066df223c83249616d619e6b396e8