### PR TITLE
Allow editing items from packing list

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -6,7 +6,7 @@ import { initializeCoreDOMElements, showPage, setupRoleBasedUI } from './ui.js';
 // No need to import uiElements object from ui.js anymore if modules get their own elements
 
 import { initializeAdminOrderPageListeners } from './adminOrderPage.js';
-import { initializeAdminItemsPageListeners } from './adminItemsPage.js';
+import { initializeAdminItemsPageListeners, loadOrderForAddingItems } from './adminItemsPage.js';
 import { initializeOperatorPackingPageListeners, loadOrderForPacking as operatorLoadOrderForPacking } from './operatorPackingPage.js';
 import { initializeDashboardPageListeners, updateCurrentDateOnDashboard, loadDashboardData } from './dashboardPage.js';
 import { initializeSupervisorPackCheckListeners, loadOrdersForPackCheck } from './supervisorPackCheckPage.js';
@@ -73,10 +73,11 @@ document.addEventListener('DOMContentLoaded', () => {
     // Expose page-specific load/setup functions to be callable from ui.js's showPage via window object
     window.updateCurrentDateOnDashboardGlobal = updateCurrentDateOnDashboard;
     window.loadDashboardDataGlobal = loadDashboardData;
-    window.loadOrdersForPackCheckGlobal = loadOrdersForPackCheck; 
+    window.loadOrdersForPackCheckGlobal = loadOrdersForPackCheck;
     window.loadOperatorPendingTasksGlobal = loadOperatorPendingTasks;
     window.setupShippingBatchPageGlobal = setupShippingBatchPage;
     window.loadOrderForPacking = operatorLoadOrderForPacking;
+    window.loadOrderForAddingItems = loadOrderForAddingItems;
 });
 
 export { auth, database, storage };

--- a/js/operatorTasksPage.js
+++ b/js/operatorTasksPage.js
@@ -17,11 +17,11 @@ export function initializeOperatorTasksPageListeners() {
 
 export async function loadOperatorPendingTasks() {
     const currentUserRole = getCurrentUserRole();
-    // Allow admin to also view this page
-    if (currentUserRole !== 'operator' && currentUserRole !== 'administrator') {
+    // Allow admin and supervisor to also view this page
+    if (currentUserRole !== 'operator' && currentUserRole !== 'administrator' && currentUserRole !== 'supervisor') {
         showAppStatus("คุณไม่มีสิทธิ์เข้าถึงหน้านี้", "error", uiElements.appStatus);
         // Consider redirecting to dashboard or login if not authorized
-        // showPage('dashboardPage'); 
+        // showPage('dashboardPage');
         return;
     }
 
@@ -56,12 +56,16 @@ export async function loadOperatorPendingTasks() {
                 orderItemDiv.style.border = '1px solid #eee';
                 orderItemDiv.style.borderRadius = '8px';
 
+                const editBtnHtml = (currentUserRole === 'administrator' || currentUserRole === 'supervisor') ?
+                    `<button type="button" class="edit-items-btn" data-orderkey="${orderKey}" style="width:auto; padding:8px 15px; margin-top:10px; margin-left:5px; font-size:0.9em; background-color:#f39c12;">แก้ไขรายการ</button>` : '';
+
                 orderItemDiv.innerHTML = `
                     <h4 style="margin-top:0; margin-bottom:8px;">Order Key: ${orderKey.length > 20 ? orderKey.substring(0,17)+'...' : orderKey}</h4>
                     <p style="font-size:0.9em; margin:3px 0;"><strong>Platform:</strong> ${orderData.platform || 'N/A'}</p>
                     <p style="font-size:0.9em; margin:3px 0;"><strong>Package Code:</strong> ${orderData.packageCode || 'N/A'}</p>
                     <p style="font-size:0.9em; margin:3px 0;"><strong>Due Date:</strong> ${orderData.dueDate ? new Date(orderData.dueDate).toLocaleDateString('th-TH') : 'N/A'}</p>
                     <button type="button" class="start-packing-btn" data-orderkey="${orderKey}" style="width:auto; padding:8px 15px; margin-top:10px; font-size:0.9em;">เริ่มแพ็กรายการนี้</button>
+                    ${editBtnHtml}
                 `;
                 uiElements.operatorOrderListContainer.appendChild(orderItemDiv);
             });
@@ -85,6 +89,19 @@ export async function loadOperatorPendingTasks() {
                     } else {
                         console.error("loadOrderForPacking function is not available globally.");
                         alert("เกิดข้อผิดพลาด: ไม่สามารถโหลดรายละเอียดออเดอร์ได้");
+                    }
+                });
+            });
+
+            // Add event listeners to the "แก้ไขรายการ" buttons (only for admin/supervisor)
+            uiElements.operatorOrderListContainer.querySelectorAll('.edit-items-btn').forEach(button => {
+                button.addEventListener('click', (e) => {
+                    const orderKeyToEdit = e.target.dataset.orderkey;
+                    if (typeof window.loadOrderForAddingItems === 'function') {
+                        window.loadOrderForAddingItems(orderKeyToEdit);
+                    } else {
+                        console.error('loadOrderForAddingItems function is not available globally.');
+                        alert('เกิดข้อผิดพลาด: ไม่สามารถโหลดหน้าปรับรายการสินค้าได้');
                     }
                 });
             });

--- a/js/ui.js
+++ b/js/ui.js
@@ -169,7 +169,7 @@ export function setupRoleBasedUI(currentUserRoleForNav) {
         if (currentUserRoleForNav === 'operator') {
             if (pageId === 'adminCreateOrderPage' || pageId === 'supervisorPackCheckListPage') btn.disabled = true;
         } else if (currentUserRoleForNav === 'supervisor') {
-            if (pageId === 'adminCreateOrderPage' || pageId === 'operatorTaskListPage' || pageId === 'operatorShippingBatchPage') btn.disabled = true;
+            if (pageId === 'adminCreateOrderPage' || pageId === 'operatorShippingBatchPage') btn.disabled = true;
         } else if (currentUserRoleForNav !== 'administrator') {
             // Unknown role: disable everything except dashboard
             if (pageId !== 'dashboardPage') btn.disabled = true;


### PR DESCRIPTION
## Summary
- expose `loadOrderForAddingItems` via main.js so other pages can launch item editing
- permit supervisors to access the operator task list in UI navigation
- allow admins and supervisors to edit items in the operator task list with new button

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68408f73e2ec8324860dc38db4881e8f