### PR TITLE
Allow admin and supervisor to pack orders

### DIFF
--- a/js/operatorPackingPage.js
+++ b/js/operatorPackingPage.js
@@ -131,7 +131,8 @@ function handlePackingPhotoSelect(event) {
 async function confirmPacking() {
     const currentUser = getCurrentUser(); const currentUserRole = getCurrentUserRole();
     if (!opPacking_appStatus) {console.error("App status element not found in confirmPacking"); return;}
-    if (currentUserRole !== 'operator' || !currentOrderKeyForPacking) { showAppStatus("ไม่มีสิทธิ์หรือไม่ได้เลือกออเดอร์", "error", opPacking_appStatus); return; }
+    if (!['operator','administrator','supervisor'].includes(currentUserRole) || !currentOrderKeyForPacking) {
+        showAppStatus("ไม่มีสิทธิ์หรือไม่ได้เลือกออเดอร์", "error", opPacking_appStatus); return; }
     if (!packingPhotoFile) { showAppStatus("กรุณาถ่ายรูปสินค้าก่อนยืนยัน", "error", opPacking_appStatus); return; }
 
     if(opPacking_confirmButton) opPacking_confirmButton.disabled = true;

--- a/js/operatorTasksPage.js
+++ b/js/operatorTasksPage.js
@@ -17,8 +17,8 @@ export function initializeOperatorTasksPageListeners() {
 
 export async function loadOperatorPendingTasks() {
     const currentUserRole = getCurrentUserRole();
-    // Allow admin to also view this page
-    if (currentUserRole !== 'operator' && currentUserRole !== 'administrator') {
+    // Allow admin and supervisor to also view this page
+    if (currentUserRole !== 'operator' && currentUserRole !== 'administrator' && currentUserRole !== 'supervisor') {
         showAppStatus("คุณไม่มีสิทธิ์เข้าถึงหน้านี้", "error", uiElements.appStatus);
         // Consider redirecting to dashboard or login if not authorized
         // showPage('dashboardPage'); 

--- a/js/ui.js
+++ b/js/ui.js
@@ -169,7 +169,7 @@ export function setupRoleBasedUI(currentUserRoleForNav) {
         if (currentUserRoleForNav === 'operator') {
             if (pageId === 'adminCreateOrderPage' || pageId === 'supervisorPackCheckListPage') btn.disabled = true;
         } else if (currentUserRoleForNav === 'supervisor') {
-            if (pageId === 'adminCreateOrderPage' || pageId === 'operatorTaskListPage' || pageId === 'operatorShippingBatchPage') btn.disabled = true;
+            if (pageId === 'adminCreateOrderPage' || pageId === 'operatorShippingBatchPage') btn.disabled = true;
         } else if (currentUserRoleForNav !== 'administrator') {
             // Unknown role: disable everything except dashboard
             if (pageId !== 'dashboardPage') btn.disabled = true;


### PR DESCRIPTION
## Summary
- enable supervisor to view the packing task list by adjusting role-based navigation
- allow supervisor on task list page
- permit administrator and supervisor roles to confirm packing

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68408fd1b4448324a0012b15cc15298c