### PR TITLE
Add inline editing for dashboard rows

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -52,4 +52,9 @@ tbody tr:hover { background-color: #f1f8ff; }
 .form-group { margin-bottom: 20px; }
 .input-group { display: flex; align-items: center; margin-bottom: 15px; }
 .input-group input[type="text"] { flex-grow: 1; margin-bottom:0; border-top-right-radius:0; border-bottom-right-radius:0; }
-.input-group button { width:auto; padding: 12px; margin-left:-1px; border-top-left-radius:0; border-bottom-left-radius:0; font-size:0.9em;}
+.input-group button { width:auto; padding: 12px; margin-left:-1px; border-top-left-radius:0; border-bottom-left-radius:0; font-size:0.9em;}.delete-order-btn{background-color:#e74c3c;padding:6px 10px;border:none;border-radius:6px;font-size:0.8em;width:auto;color:#fff;margin-left:5px;}
+.delete-order-btn:hover{background-color:#c0392b;}
+.save-order-btn{background-color:#27ae60;padding:6px 10px;border:none;border-radius:6px;font-size:0.8em;width:auto;color:#fff;margin-right:5px;}
+.save-order-btn:hover{background-color:#1e8449;}
+.cancel-edit-btn{background-color:#7f8c8d;padding:6px 10px;border:none;border-radius:6px;font-size:0.8em;width:auto;color:#fff;}
+.cancel-edit-btn:hover{background-color:#606f70;}

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
                     </div>
                     <div id="ordersTableContainer" style="max-height: 400px; overflow-y: auto; border:1px solid #ccc;">
                         <table><thead><tr style="background-color:#f0f0f0;">
-                            <th>Order Key</th><th>Platform</th><th>Package Code</th><th>สถานะ</th><th>Due Date</th><th>Actions</th>
+                            <th>Order Key</th><th>Platform Order ID</th><th>Platform</th><th>Package Code</th><th>สถานะ</th><th>Due Date</th><th>Actions</th>
                         </tr></thead><tbody id="ordersTableBody"></tbody></table>
                     </div>
                     <p id="noOrdersMessage" class="hidden" style="text-align:center; padding:20px;">ไม่พบข้อมูลพัสดุ</p>


### PR DESCRIPTION
## Summary
- enable editing platform order ID, package code, status and due date directly in the dashboard table
- add Save and Cancel buttons for inline editing
- style Save and Cancel actions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841b874b3a48324932a14f65cdd5275