### PR TITLE
Hide order key display

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
                     </div>
                     <div id="ordersTableContainer" style="max-height: 400px; overflow-y: auto; border:1px solid #ccc;">
                         <table><thead><tr style="background-color:#f0f0f0;">
-                            <th>Order Key</th><th>Platform Order ID</th><th>Platform</th><th>Package Code</th><th>สถานะ</th><th>Due Date</th><th>Actions</th>
+                            <th>Package Code</th><th>Platform Order ID</th><th>Platform</th><th>สถานะ</th><th>Due Date</th><th>Actions</th>
                         </tr></thead><tbody id="ordersTableBody"></tbody></table>
                     </div>
                     <p id="noOrdersMessage" class="hidden" style="text-align:center; padding:20px;">ไม่พบข้อมูลพัสดุ</p>
@@ -97,7 +97,7 @@
                 <button id="saveInitialOrderButton" type="button">บันทึกออเดอร์เบื้องต้น</button>
 
                 <div id="adminAddItemsSection" class="hidden" style="margin-top:20px; border-top:1px solid #ccc; padding-top:20px;">
-                    <h2>เพิ่มรายการสินค้า (Order ID: <span id="currentOrderIdForItems"></span>)</h2>
+                    <h2>เพิ่มรายการสินค้า (Package Code: <span id="currentOrderIdForItems"></span>)</h2>
                     <label for="productSearch">ค้นหาสินค้า:</label>
                     <input type="text" id="productSearch" placeholder="พิมพ์ชื่อสินค้า...">
                     <label for="quantity">จำนวน:</label>
@@ -113,7 +113,7 @@
             
             <!-- Operator: Packing Page (หน้ารายละเอียดการแพ็กแต่ละออเดอร์) -->
             <div id="operatorPackingPage" class="container page hidden">
-                <h2>แพ็กสินค้า (Order ID: <span id="currentOrderIdForPacking"></span>)</h2>
+                <h2>แพ็กสินค้า (Package Code: <span id="currentOrderIdForPacking"></span>)</h2>
                 <p><strong>Platform:</strong> <span id="packOrderPlatform"></span></p>
                 <p><strong>Due Date:</strong> <span id="packOrderDueDate"></span></p>
                 <h3>Checklist รายการสินค้า:</h3>
@@ -210,10 +210,9 @@
 
             <!-- Supervisor: Individual Pack Check Page -->
             <div id="supervisorIndividualPackCheckPage" class="container page hidden">
-                <h2>ตรวจสอบการแพ็ก Order: <span id="checkOrderKeyDisplay"></span></h2>
+                <h2>ตรวจสอบการแพ็ก (Package Code: <span id="checkOrderPackageCodeDisplay"></span>)</h2>
                 <div>
                     <p><strong>Platform:</strong> <span id="checkOrderPlatformDisplay"></span></p>
-                    <p><strong>Package Code:</strong> <span id="checkOrderPackageCodeDisplay"></span></p>
                     <h3>รายการสินค้าที่ควรมี:</h3>
                     <ul id="checkOrderItemListDisplay" class="item-checklist"></ul>
                 </div>

--- a/js/adminItemsPage.js
+++ b/js/adminItemsPage.js
@@ -53,7 +53,6 @@ export async function loadOrderForAddingItems(orderKey) {
         return;
     }
     currentOrderKeyForItems = orderKey;
-    if (adminItemsCurrentOrderIdSpan) adminItemsCurrentOrderIdSpan.textContent = orderKey;
     if (adminItemsProductSearchInput) adminItemsProductSearchInput.value = '';
     if (adminItemsQuantityInput) adminItemsQuantityInput.value = '1';
     if (adminItemsUnitInput) adminItemsUnitInput.value = '';
@@ -63,6 +62,7 @@ export async function loadOrderForAddingItems(orderKey) {
         const snap = await get(ref(database, 'orders/' + orderKey));
         if (snap.exists()) {
             const data = snap.val();
+            if (adminItemsCurrentOrderIdSpan) adminItemsCurrentOrderIdSpan.textContent = data.packageCode || orderKey;
             if (data.items) {
                 Object.keys(data.items).forEach(id => {
                     renderItemInList(id, data.items[id]);

--- a/js/dashboardPage.js
+++ b/js/dashboardPage.js
@@ -113,16 +113,15 @@ function updateOrdersLogTable(orders, filterStatus = 'all') {
     el_ordersTableBody.innerHTML = '';
     const filtered = filterStatus === 'all' ? orders : orders.filter(o => o.status === filterStatus);
     if (filtered.length === 0) {
-        const r = el_ordersTableBody.insertRow(); const c = r.insertCell(); c.colSpan = 7; c.textContent = "ไม่พบข้อมูล"; c.style.textAlign = "center"; c.style.padding="20px"; return;
+        const r = el_ordersTableBody.insertRow(); const c = r.insertCell(); c.colSpan = 6; c.textContent = "ไม่พบข้อมูล"; c.style.textAlign = "center"; c.style.padding="20px"; return;
     }
     const role = getCurrentUserRole();
     filtered.forEach(o => {
         const r = el_ordersTableBody.insertRow();
         r.dataset.orderkey = o.key;
-        r.insertCell().textContent = o.key && o.key.length > 20 ? o.key.substring(0,17)+'...' : (o.key || 'N/A');
+        r.insertCell().textContent = o.packageCode || 'N/A';
         r.insertCell().textContent = o.platformOrderId || '-';
         r.insertCell().textContent = o.platform || 'N/A';
-        r.insertCell().textContent = o.packageCode || 'N/A';
         r.insertCell().textContent = o.status || 'N/A';
         r.insertCell().textContent = o.dueDate ? new Date(o.dueDate).toLocaleDateString('th-TH',{day:'2-digit',month:'short',year:'numeric'}) : 'N/A';
         const actCell = r.insertCell();
@@ -155,10 +154,10 @@ async function handleEditOrder(orderKey) {
     row.dataset.editing = 'true';
 
     const cells = row.querySelectorAll('td');
+    const packageCodeCell = cells[0];
     const platformOrderCell = cells[1];
-    const packageCodeCell = cells[3];
-    const statusCell = cells[4];
-    const actionsCell = cells[6];
+    const statusCell = cells[3];
+    const actionsCell = cells[5];
 
     const platformOrderInput = document.createElement('input');
     platformOrderInput.type = 'text';

--- a/js/operatorPackingPage.js
+++ b/js/operatorPackingPage.js
@@ -50,14 +50,14 @@ export function initializeOperatorPackingPageListeners() {
 export async function loadOrderForPacking(orderKey) {
     if (!opPacking_appStatus) { console.error("App status element missing in loadOrderForPacking"); return; }
     if (!orderKey) {
-        showAppStatus("ไม่พบ Order Key สำหรับการแพ็ก", "error", opPacking_appStatus);
+        showAppStatus('ไม่พบรหัสพัสดุสำหรับการแพ็ก', 'error', opPacking_appStatus);
         showPage('dashboardPage'); // Or operator's task list
         return;
     }
     currentOrderKeyForPacking = orderKey;
     packingPhotoFile = null;
 
-    showAppStatus(`กำลังโหลดข้อมูลออเดอร์ ${orderKey}...`, "info", opPacking_appStatus);
+    showAppStatus('กำลังโหลดข้อมูลพัสดุ...', 'info', opPacking_appStatus);
 
     const orderRef = ref(database, 'orders/' + orderKey);
     try {
@@ -65,13 +65,13 @@ export async function loadOrderForPacking(orderKey) {
         if (snapshot.exists()) {
             const orderData = snapshot.val();
             if (orderData.status !== "Ready to Pack" && orderData.status !== "Pack Rejected") {
-                alert(`ออเดอร์ ${orderKey} ไม่พร้อมสำหรับการแพ็ก (สถานะ: ${orderData.status})`);
-                showAppStatus(`ออเดอร์ ${orderKey} สถานะ: ${orderData.status}`, "info", opPacking_appStatus);
+                alert(`พัสดุนี้ไม่พร้อมสำหรับการแพ็ก (สถานะ: ${orderData.status})`);
+                showAppStatus(`พัสดุสถานะ: ${orderData.status}`, 'info', opPacking_appStatus);
                 showPage('dashboardPage'); // Or back to operator's task list
                 return;
             }
 
-            if(opPacking_currentOrderIdSpan) opPacking_currentOrderIdSpan.textContent = orderKey;
+            if(opPacking_currentOrderIdSpan) opPacking_currentOrderIdSpan.textContent = orderData.packageCode || orderKey;
             if(opPacking_platformSpan) opPacking_platformSpan.textContent = orderData.platform || 'N/A';
             if(opPacking_dueDateSpan) opPacking_dueDateSpan.textContent = orderData.dueDate ? new Date(orderData.dueDate).toLocaleDateString('th-TH') : 'N/A';
             
@@ -101,15 +101,15 @@ export async function loadOrderForPacking(orderKey) {
             if(opPacking_notesTextarea) opPacking_notesTextarea.value = orderData.packingInfo?.operatorNotes || '';
             
             showPage('operatorPackingPage');
-            showAppStatus(`โหลดออเดอร์ ${orderKey} สำหรับแพ็กแล้ว`, "success", opPacking_appStatus);
+            showAppStatus('โหลดพัสดุสำหรับแพ็กแล้ว', 'success', opPacking_appStatus);
         } else {
-            alert(`ไม่พบข้อมูลออเดอร์ ID: ${orderKey}`);
-            showAppStatus(`ไม่พบออเดอร์ ID: ${orderKey}`, "error", opPacking_appStatus);
+            alert('ไม่พบข้อมูลพัสดุนี้');
+            showAppStatus('ไม่พบข้อมูลพัสดุนี้', 'error', opPacking_appStatus);
             showPage('dashboardPage'); // Or back to operator's task list
         }
     } catch (error) {
         console.error(`Error loading order ${orderKey} for packing:`, error);
-        showAppStatus("เกิดข้อผิดพลาดในการโหลดข้อมูลออเดอร์: " + error.message, "error", opPacking_appStatus);
+        showAppStatus('เกิดข้อผิดพลาดในการโหลดข้อมูลพัสดุ: ' + error.message, 'error', opPacking_appStatus);
         showPage('dashboardPage'); // Or back to operator's task list
     }
 }
@@ -132,7 +132,7 @@ async function confirmPacking() {
     const currentUser = getCurrentUser(); const currentUserRole = getCurrentUserRole();
     if (!opPacking_appStatus) {console.error("App status element not found in confirmPacking"); return;}
     if (!['operator','administrator','supervisor'].includes(currentUserRole) || !currentOrderKeyForPacking) {
-        showAppStatus("ไม่มีสิทธิ์หรือไม่ได้เลือกออเดอร์", "error", opPacking_appStatus); return; }
+        showAppStatus('ไม่มีสิทธิ์หรือไม่ได้เลือกพัสดุ', 'error', opPacking_appStatus); return; }
     if (!packingPhotoFile) { showAppStatus("กรุณาถ่ายรูปสินค้าก่อนยืนยัน", "error", opPacking_appStatus); return; }
 
     if(opPacking_confirmButton) opPacking_confirmButton.disabled = true;

--- a/js/operatorShippingPage.js
+++ b/js/operatorShippingPage.js
@@ -139,11 +139,11 @@ function startScanForBatch() {
 
             if (orderKeyFound) {
                 if (itemsInCurrentBatch[orderKeyFound]) {
-                    showAppStatus(`พัสดุ ${packageCodeScanned} (Order: ${orderKeyFound}) อยู่ใน Batch นี้แล้ว`, "info", uiElements.appStatus);
+                    showAppStatus(`พัสดุ ${packageCodeScanned} อยู่ใน Batch นี้แล้ว`, 'info', uiElements.appStatus);
                 } else {
                     itemsInCurrentBatch[orderKeyFound] = packageCodeScanned; // Store package code for display
                     renderBatchItems();
-                    showAppStatus(`เพิ่ม ${packageCodeScanned} (Order: ${orderKeyFound}) เข้า Batch สำเร็จ`, "success", uiElements.appStatus);
+                    showAppStatus(`เพิ่ม ${packageCodeScanned} เข้า Batch สำเร็จ`, 'success', uiElements.appStatus);
                 }
             } else {
                 showAppStatus(`ไม่พบออเดอร์ที่พร้อมส่งสำหรับรหัสพัสดุ: ${packageCodeScanned} หรือสถานะไม่ถูกต้อง`, "error", uiElements.appStatus);
@@ -195,7 +195,7 @@ function renderBatchItems() {
     for (const orderKey in itemsInCurrentBatch) {
         const packageCode = itemsInCurrentBatch[orderKey];
         const li = document.createElement('li');
-        li.textContent = `Order: ${orderKey.substring(0,10)}... - Pkg: ${packageCode}`;
+        li.textContent = packageCode;
         // Add a remove button if needed
         uiElements.batchItemList.appendChild(li);
     }

--- a/js/operatorTasksPage.js
+++ b/js/operatorTasksPage.js
@@ -63,9 +63,8 @@ export async function loadOperatorPendingTasks() {
                     `<button type="button" class="delete-order-btn" data-orderkey="${orderKey}" style="width:auto; padding:8px 15px; margin-top:10px; margin-left:5px; font-size:0.9em; background-color:#e74c3c;">ลบ</button>` : '';
 
                 orderItemDiv.innerHTML = `
-                    <h4 style="margin-top:0; margin-bottom:8px;">Order Key: ${orderKey.length > 20 ? orderKey.substring(0,17)+'...' : orderKey}</h4>
+                    <h4 style="margin-top:0; margin-bottom:8px;">Package Code: ${orderData.packageCode || 'N/A'}</h4>
                     <p style="font-size:0.9em; margin:3px 0;"><strong>Platform:</strong> ${orderData.platform || 'N/A'}</p>
-                    <p style="font-size:0.9em; margin:3px 0;"><strong>Package Code:</strong> ${orderData.packageCode || 'N/A'}</p>
                     <p style="font-size:0.9em; margin:3px 0;"><strong>Due Date:</strong> ${orderData.dueDate ? new Date(orderData.dueDate).toLocaleDateString('th-TH') : 'N/A'}</p>
                     <button type="button" class="start-packing-btn" data-orderkey="${orderKey}" style="width:auto; padding:8px 15px; margin-top:10px; font-size:0.9em;">เริ่มแพ็กรายการนี้</button>
                     ${editBtnHtml}

--- a/js/supervisorPackCheckPage.js
+++ b/js/supervisorPackCheckPage.js
@@ -68,9 +68,8 @@ export async function loadOrdersForPackCheck() {
 
                 // Display some key information about the order
                 orderItemDiv.innerHTML = `
-                    <h4 style="margin-top:0; margin-bottom:8px;">Order Key: ${orderKey.length > 20 ? orderKey.substring(0,17)+'...' : orderKey}</h4>
+                    <h4 style="margin-top:0; margin-bottom:8px;">Package Code: ${orderData.packageCode || 'N/A'}</h4>
                     <p style="font-size:0.9em; margin:3px 0;"><strong>Platform:</strong> ${orderData.platform || 'N/A'}</p>
-                    <p style="font-size:0.9em; margin:3px 0;"><strong>Package Code:</strong> ${orderData.packageCode || 'N/A'}</p>
                     <p style="font-size:0.9em; margin:3px 0;"><strong>Packed by (Operator UID):</strong> ${orderData.packingInfo?.packedBy_operatorUid?.substring(0,8) || 'N/A'}...</p>
                     <button type="button" class="supervisor-check-btn" data-orderkey="${orderKey}" style="width:auto; padding:8px 15px; margin-top:10px; font-size:0.9em;">ตรวจสอบรายการนี้</button>
                 `;
@@ -106,10 +105,10 @@ export async function loadOrdersForPackCheck() {
 
 async function loadIndividualOrderForSupervisorCheck(orderKey) {
     currentOrderKeyForSupervisorCheck = orderKey; // Store the key for approve/reject actions
-    showAppStatus(`กำลังโหลดรายละเอียด Order ${orderKey} สำหรับการตรวจสอบ...`, "info", uiElements.appStatus);
+    showAppStatus(`กำลังโหลดรายละเอียดพัสดุสำหรับการตรวจสอบ...`, "info", uiElements.appStatus);
 
     // Ensure all relevant DOM elements for the individual check page are available
-    if (!uiElements.checkOrderKeyDisplay || !uiElements.checkOrderPlatformDisplay || !uiElements.checkOrderPackageCodeDisplay ||
+    if (!uiElements.checkOrderPackageCodeDisplay || !uiElements.checkOrderPlatformDisplay ||
         !uiElements.checkOrderItemListDisplay || !uiElements.checkOrderPackingPhotoDisplay ||
         !uiElements.checkOrderOperatorNotesDisplay || !uiElements.supervisorPackCheckNotes ||
         !uiElements.approvePackButton || !uiElements.rejectPackButton) {
@@ -124,9 +123,8 @@ async function loadIndividualOrderForSupervisorCheck(orderKey) {
         if (snapshot.exists()) {
             const orderData = snapshot.val();
             
-            uiElements.checkOrderKeyDisplay.textContent = orderKey;
-            uiElements.checkOrderPlatformDisplay.textContent = orderData.platform || 'N/A';
             uiElements.checkOrderPackageCodeDisplay.textContent = orderData.packageCode || 'N/A';
+            uiElements.checkOrderPlatformDisplay.textContent = orderData.platform || 'N/A';
             
             uiElements.checkOrderItemListDisplay.innerHTML = ''; // Clear previous items
             if(orderData.items){
@@ -145,20 +143,20 @@ async function loadIndividualOrderForSupervisorCheck(orderKey) {
             uiElements.supervisorPackCheckNotes.value = ''; // Clear supervisor's previous notes for this new check
 
             showPage('supervisorIndividualPackCheckPage'); // Show the page with details
-            showAppStatus(`แสดงรายละเอียด Order ${orderKey} สำหรับการตรวจสอบ`, "success", uiElements.appStatus);
+            showAppStatus('แสดงรายละเอียดพัสดุสำหรับการตรวจสอบ', 'success', uiElements.appStatus);
         } else {
-            showAppStatus(`ไม่พบข้อมูล Order ${orderKey}`, "error", uiElements.appStatus);
+            showAppStatus('ไม่พบข้อมูลพัสดุนี้', 'error', uiElements.appStatus);
             showPage('supervisorPackCheckListPage'); // Go back to the list if order not found
         }
     } catch (error) {
         console.error("Error loading individual order for supervisor check:", error);
-        showAppStatus("เกิดข้อผิดพลาดในการโหลดรายละเอียดออเดอร์: " + error.message, "error", uiElements.appStatus);
+        showAppStatus("เกิดข้อผิดพลาดในการโหลดรายละเอียดพัสดุ: " + error.message, 'error', uiElements.appStatus);
     }
 }
 
 async function handleSupervisorPackAction(isApproved) {
     if (!currentOrderKeyForSupervisorCheck) {
-        showAppStatus("ไม่ได้เลือกออเดอร์ที่จะดำเนินการตรวจสอบ", "error", uiElements.appStatus);
+        showAppStatus("ไม่ได้เลือกพัสดุที่จะดำเนินการตรวจสอบ", 'error', uiElements.appStatus);
         return;
     }
     const currentUser = getCurrentUser(); // From auth.js
@@ -184,13 +182,13 @@ async function handleSupervisorPackAction(isApproved) {
     updates[`/orders/${currentOrderKeyForSupervisorCheck}/lastUpdatedAt`] = serverTimestamp();
 
     const actionText = isApproved ? 'อนุมัติ' : 'ปฏิเสธ';
-    showAppStatus(`กำลัง${actionText}การแพ็กสำหรับ Order ${currentOrderKeyForSupervisorCheck}...`, "info", uiElements.appStatus);
+    showAppStatus(`กำลัง${actionText}การแพ็ก...`, 'info', uiElements.appStatus);
     uiElements.approvePackButton.disabled = true;
     uiElements.rejectPackButton.disabled = true;
 
     try {
         await update(ref(database), updates); // Perform the multi-location update
-        showAppStatus(`การแพ็กของ Order ${currentOrderKeyForSupervisorCheck} ได้ถูก${actionText}แล้ว`, "success", uiElements.appStatus);
+        showAppStatus(`การแพ็กได้ถูก${actionText}แล้ว`, 'success', uiElements.appStatus);
         
         currentOrderKeyForSupervisorCheck = null; // Reset current order key
         showPage('supervisorPackCheckListPage'); // Navigate back to the list

--- a/js/ui.js
+++ b/js/ui.js
@@ -51,9 +51,8 @@ export function initializeCoreDOMElements() { // Renamed for clarity
     uiElements.noPackCheckOrdersMessage = document.getElementById('noPackCheckOrdersMessage');
     uiElements.approvePackButton = document.getElementById('approvePackButton');
     uiElements.rejectPackButton = document.getElementById('rejectPackButton');
-    uiElements.checkOrderKeyDisplay = document.getElementById('checkOrderKeyDisplay');
-    uiElements.checkOrderPlatformDisplay = document.getElementById('checkOrderPlatformDisplay');
     uiElements.checkOrderPackageCodeDisplay = document.getElementById('checkOrderPackageCodeDisplay');
+    uiElements.checkOrderPlatformDisplay = document.getElementById('checkOrderPlatformDisplay');
     uiElements.checkOrderItemListDisplay = document.getElementById('checkOrderItemListDisplay');
     uiElements.checkOrderPackingPhotoDisplay = document.getElementById('checkOrderPackingPhotoDisplay');
     uiElements.checkOrderOperatorNotesDisplay = document.getElementById('checkOrderOperatorNotesDisplay');


### PR DESCRIPTION
## Summary
- remove order key column from the dashboard table and show package codes instead
- show package code in item and packing pages
- adjust supervisor check UI to reference package codes
- drop order key from shipping batch messages

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68428bdb082c832488149e796f05337b