### PR TITLE
Improve display info and order page UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 
         <!-- Main App Area (Content will be dynamically shown) -->
         <div id="mainApp" class="hidden">
-            <div class="user-info">Logged in as: <span id="userDisplayEmail"></span> (<span id="userDisplayRole"></span>)<button id="logoutButton" type="button">Logout</button></div>
+            <div class="user-info">Logged in as: <span id="userDisplayName"></span> (<span id="userDisplayEmail"></span>, <span id="userDisplayRole"></span>)<button id="logoutButton" type="button">Logout</button></div>
             
             <!-- Dashboard Page -->
             <div id="dashboardPage" class="container page current-page">

--- a/js/adminOrderPage.js
+++ b/js/adminOrderPage.js
@@ -53,6 +53,9 @@ export function initializeAdminOrderPageListeners() {
     adminOrderScanPlatformIdButton.addEventListener('click', startPlatformIdScan);
     adminOrderStopPlatformIdQRButton.addEventListener('click', stopPlatformIdScan);
     adminOrderSaveButton.addEventListener('click', saveInitialOrder);
+    if (adminOrderPackageCodeInput) {
+        adminOrderPackageCodeInput.addEventListener('input', onPackageCodeInputChange);
+    }
     if (scanOverlayDiv) {
         scanOverlayDiv.addEventListener('click', (e) => {
             if (e.target === scanOverlayDiv) {
@@ -235,5 +238,15 @@ async function saveInitialOrder() {
         showAppStatus('เกิดข้อผิดพลาด: ' + err.message, 'error', adminOrderAppStatus);
     } finally {
         if (adminOrderSaveButton) adminOrderSaveButton.disabled = false;
+    }
+}
+
+function onPackageCodeInputChange() {
+    const packageCode = adminOrderPackageCodeInput ? adminOrderPackageCodeInput.value.trim() : '';
+    if (adminOrderScannedQRData) {
+        adminOrderScannedQRData.textContent = packageCode || 'N/A';
+    }
+    if (adminOrderPlatformInput) {
+        adminOrderPlatformInput.value = detectPlatformFromPackageCode(packageCode);
     }
 }

--- a/js/dashboardPage.js
+++ b/js/dashboardPage.js
@@ -136,6 +136,8 @@ function updateOrdersLogTable(orders, filterStatus = 'all') {
             delBtn.className = 'delete-order-btn';
             delBtn.dataset.orderkey = o.key;
             actCell.appendChild(delBtn);
+            delBtn.addEventListener('click', () => handleDeleteOrder(o.key));
+            btn.addEventListener('click', () => handleEditOrder(o.key));
         } else {
             actCell.textContent = '-';
         }

--- a/js/main.js
+++ b/js/main.js
@@ -16,30 +16,34 @@ import { initializeOperatorShippingPageListeners, setupShippingBatchPage } from 
 window.currentUserFromAuth = null; 
 window.currentUserRoleFromAuth = null;
 
-function setCurrentUserAndUpdateUI(user, role) {
+function setCurrentUserAndUpdateUI(user, role, displayName) {
     window.currentUserFromAuth = user;
     window.currentUserRoleFromAuth = role;
-    console.log("User state updated in main.js: User:", user ? user.email : null, "Role:", role);
+    window.currentUserDisplayNameFromAuth = displayName;
+    console.log("User state updated in main.js: User:", user ? user.email : null, "Role:", role, "Name:", displayName);
     
     // Get global UI elements directly here if needed, or assume ui.js handles its own global elements
+    const userDisplayNameEl = document.getElementById('userDisplayName');
     const userDisplayEmailEl = document.getElementById('userDisplayEmail');
     const userDisplayRoleEl = document.getElementById('userDisplayRole');
     const loginPageEl = document.getElementById('loginPage');
     const mainAppEl = document.getElementById('mainApp');
     const bottomNavContainerEl = document.getElementById('bottomNavContainer');
 
-    if (userDisplayEmailEl && userDisplayRoleEl && loginPageEl && mainAppEl && bottomNavContainerEl) {
-        if (user) { 
+    if (userDisplayEmailEl && userDisplayRoleEl && userDisplayNameEl && loginPageEl && mainAppEl && bottomNavContainerEl) {
+        if (user) {
             userDisplayEmailEl.textContent = user.email;
             userDisplayRoleEl.textContent = role || 'N/A';
+            if (userDisplayNameEl) userDisplayNameEl.textContent = displayName || user.displayName || '';
             loginPageEl.classList.add('hidden');
             mainAppEl.classList.remove('hidden');
             bottomNavContainerEl.classList.remove('hidden');
             setupRoleBasedUI(role); // This function is imported from ui.js and uses its own DOM knowledge
             showPage('dashboardPage'); // This function is imported from ui.js
-        } else { 
+        } else {
             userDisplayEmailEl.textContent = '';
             userDisplayRoleEl.textContent = '';
+            if (userDisplayNameEl) userDisplayNameEl.textContent = '';
             mainAppEl.classList.add('hidden');
             bottomNavContainerEl.classList.add('hidden');
             if(bottomNavContainerEl) bottomNavContainerEl.innerHTML = ''; // Check if exists


### PR DESCRIPTION
## Summary
- show user display name in header
- fetch display name from Firebase auth data
- auto detect platform when typing package code
- bind dashboard delete button directly to work properly

## Testing
- `npm test` *(fails: ENOENT because package.json is missing)*

------
https://chatgpt.com/codex/tasks/task_e_684299cc4c448324a6fd49e32c1a0f24