### PR TITLE
Fix dashboard listing and move items page

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,19 +96,21 @@
 
                 <button id="saveInitialOrderButton" type="button">บันทึกออเดอร์เบื้องต้น</button>
 
-                <div id="adminAddItemsSection" class="hidden" style="margin-top:20px; border-top:1px solid #ccc; padding-top:20px;">
-                    <h2>เพิ่มรายการสินค้า (Package Code: <span id="currentOrderIdForItems"></span>)</h2>
-                    <label for="productSearch">ค้นหาสินค้า:</label>
-                    <input type="text" id="productSearch" placeholder="พิมพ์ชื่อสินค้า...">
-                    <label for="quantity">จำนวน:</label>
-                    <input type="number" id="quantity" value="1" min="1">
-                    <label for="unit">หน่วย:</label>
-                    <input type="text" id="unit" placeholder="เช่น ตัว, ชิ้น">
-                    <button id="addItemToOrderButton" type="button">เพิ่มสินค้าในรายการ</button>
-                    <h3>รายการสินค้าที่เพิ่มแล้ว:</h3>
-                    <ul id="itemListCurrentOrder" class="item-checklist"></ul>
-                    <button id="confirmAllItemsButton" type="button">ยืนยันรายการสินค้าทั้งหมด</button>
-                </div>
+            </div>
+
+            <!-- Admin: Add Items Page -->
+            <div id="adminItemsPage" class="container page hidden">
+                <h2>เพิ่มรายการสินค้า (Package Code: <span id="currentOrderIdForItems"></span>)</h2>
+                <label for="productSearch">ค้นหาสินค้า:</label>
+                <input type="text" id="productSearch" placeholder="พิมพ์ชื่อสินค้า...">
+                <label for="quantity">จำนวน:</label>
+                <input type="number" id="quantity" value="1" min="1">
+                <label for="unit">หน่วย:</label>
+                <input type="text" id="unit" placeholder="เช่น ตัว, ชิ้น">
+                <button id="addItemToOrderButton" type="button">เพิ่มสินค้าในรายการ</button>
+                <h3>รายการสินค้าที่เพิ่มแล้ว:</h3>
+                <ul id="itemListCurrentOrder" class="item-checklist"></ul>
+                <button id="confirmAllItemsButton" type="button">ยืนยันรายการสินค้าทั้งหมด</button>
             </div>
             
             <!-- Operator: Packing Page (หน้ารายละเอียดการแพ็กแต่ละออเดอร์) -->

--- a/js/adminItemsPage.js
+++ b/js/adminItemsPage.js
@@ -78,9 +78,7 @@ export async function loadOrderForAddingItems(orderKey) {
         console.error('loadOrderForAddingItems error', err);
         showAppStatus('เกิดข้อผิดพลาด', 'error', adminItemsAppStatus);
     }
-    showPage('adminCreateOrderPage');
-    const section = document.getElementById('adminAddItemsSection');
-    if(section) section.classList.remove('hidden');
+    showPage('adminItemsPage');
 }
 
 function renderItemInList(itemId, itemData) {
@@ -131,8 +129,6 @@ async function confirmAllItems() {
         });
         showAppStatus('ยืนยันรายการสินค้าแล้ว', 'success', adminItemsAppStatus);
         currentOrderKeyForItems = null;
-        const section = document.getElementById('adminAddItemsSection');
-        if(section) section.classList.add('hidden');
         showPage('dashboardPage');
     } catch(err) {
         console.error('confirmAllItems error', err);

--- a/js/dashboardPage.js
+++ b/js/dashboardPage.js
@@ -1,6 +1,6 @@
 // js/dashboardPage.js
 import { database } from './config.js';
-import { ref, get, query, orderByChild, limitToLast, update, remove, serverTimestamp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-database.js";
+import { ref, get, update, remove, serverTimestamp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-database.js";
 import { showAppStatus } from './utils.js';
 import { getCurrentUser, getCurrentUserRole } from './auth.js';
 // ไม่ต้อง import uiElements จาก ui.js แล้ว
@@ -64,12 +64,14 @@ export async function loadDashboardData(filterStatus = 'all') {
 
     try {
         const ordersRefNode = ref(database, 'orders');
-        const dataQuery = query(ordersRefNode, orderByChild('createdAt'), limitToLast(150));
-        const snapshot = await get(dataQuery);
+        const snapshot = await get(ordersRefNode);
         let allOrders = [];
         if (snapshot.exists()) {
-            snapshot.forEach(childSnapshot => allOrders.push({ key: childSnapshot.key, ...childSnapshot.val() }));
+            snapshot.forEach(childSnapshot => {
+                allOrders.push({ key: childSnapshot.key, ...childSnapshot.val() });
+            });
             allOrders.sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
+            allOrders = allOrders.slice(0, 150);
         }
 
         updateSummaryCards(allOrders);

--- a/js/ui.js
+++ b/js/ui.js
@@ -113,8 +113,6 @@ export function showPage(pageId) {
             if(platformInput) platformInput.readOnly = true;
             const packageCodeInput = document.getElementById('adminPackageCode');
             if(packageCodeInput) packageCodeInput.readOnly = false;
-            const addItemsSection = document.getElementById('adminAddItemsSection');
-            if(addItemsSection) addItemsSection.classList.add('hidden');
 
         } else if (pageId === 'dashboardPage') {
             if (window.currentUserFromAuth) {


### PR DESCRIPTION
## Summary
- limit dashboard query issues by fetching all orders then sorting
- split add items form into new admin items page
- update item page logic and UI utilities

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842ad38da3083249144cab3c6613027