### PR TITLE
Add photo remove option on packing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,6 +123,7 @@
                 <label for="packingPhoto">ถ่ายรูปสินค้าที่เตรียม:</label>
                 <input type="file" id="packingPhoto" accept="image/*" capture="environment">
                 <img id="packingPhotoPreview" src="#" alt="Preview" class="hidden">
+                <button id="removePackingPhotoButton" type="button" class="secondary hidden" style="width:auto; margin-top:10px;">ลบรูป / ถ่ายใหม่</button>
                 <label for="operatorPackNotes">หมายเหตุ (ถ้ามี):</label>
                 <textarea id="operatorPackNotes"></textarea>
                 <button id="confirmPackingButton" type="button">ยืนยันการแพ็ก</button>

--- a/js/operatorPackingPage.js
+++ b/js/operatorPackingPage.js
@@ -12,7 +12,7 @@ let packingPhotoFile = null;
 // DOM Elements for this page - to be initialized
 let opPacking_pageElement, opPacking_currentOrderIdSpan, opPacking_platformSpan, opPacking_dueDateSpan,
     opPacking_itemListUL, opPacking_photoInput, opPacking_photoPreviewImg,
-    opPacking_notesTextarea, opPacking_confirmButton, opPacking_supervisorCheckResultDiv,
+    opPacking_removePhotoButton, opPacking_notesTextarea, opPacking_confirmButton, opPacking_supervisorCheckResultDiv,
     opPacking_packCheckStatusSpan, opPacking_packCheckSupervisorSpan, opPacking_packCheckNotesSpan,
     opPacking_appStatus;
 
@@ -25,6 +25,7 @@ export function initializeOperatorPackingPageListeners() {
     opPacking_itemListUL = document.getElementById('packOrderItemList');
     opPacking_photoInput = document.getElementById('packingPhoto');
     opPacking_photoPreviewImg = document.getElementById('packingPhotoPreview');
+    opPacking_removePhotoButton = document.getElementById('removePackingPhotoButton');
     opPacking_notesTextarea = document.getElementById('operatorPackNotes');
     opPacking_confirmButton = document.getElementById('confirmPackingButton');
     opPacking_supervisorCheckResultDiv = document.getElementById('supervisorPackCheckResult');
@@ -39,6 +40,7 @@ export function initializeOperatorPackingPageListeners() {
     }
 
     opPacking_photoInput.addEventListener('change', handlePackingPhotoSelect);
+    if (opPacking_removePhotoButton) opPacking_removePhotoButton.addEventListener('click', resetPackingPhoto);
     opPacking_confirmButton.addEventListener('click', confirmPacking);
 
     // Make navigateToOperatorScanToPack globally accessible for the nav button (if called from HTML onclick)
@@ -97,7 +99,8 @@ export async function loadOrderForPacking(orderKey) {
             }
 
             if(opPacking_photoInput) opPacking_photoInput.value = '';
-            if(opPacking_photoPreviewImg) { opPacking_photoPreviewImg.classList.add('hidden'); opPacking_photoPreviewImg.src = '#';}
+            if(opPacking_photoPreviewImg) { opPacking_photoPreviewImg.classList.add('hidden'); opPacking_photoPreviewImg.src = '#'; }
+            if(opPacking_removePhotoButton) opPacking_removePhotoButton.classList.add('hidden');
             if(opPacking_notesTextarea) opPacking_notesTextarea.value = orderData.packingInfo?.operatorNotes || '';
             
             showPage('operatorPackingPage');
@@ -120,12 +123,23 @@ function handlePackingPhotoSelect(event) {
     if (file) {
         packingPhotoFile = file;
         const reader = new FileReader();
-        reader.onload = (e) => { opPacking_photoPreviewImg.src = e.target.result; opPacking_photoPreviewImg.classList.remove('hidden'); }
+        reader.onload = (e) => { opPacking_photoPreviewImg.src = e.target.result; opPacking_photoPreviewImg.classList.remove('hidden'); };
         reader.readAsDataURL(file);
+        if (opPacking_removePhotoButton) opPacking_removePhotoButton.classList.remove('hidden');
     } else {
         packingPhotoFile = null;
         opPacking_photoPreviewImg.classList.add('hidden'); opPacking_photoPreviewImg.src = '#';
+        if (opPacking_removePhotoButton) opPacking_removePhotoButton.classList.add('hidden');
     }
+}
+
+function resetPackingPhoto() {
+    if (!opPacking_photoInput || !opPacking_photoPreviewImg) return;
+    opPacking_photoInput.value = '';
+    packingPhotoFile = null;
+    opPacking_photoPreviewImg.src = '#';
+    opPacking_photoPreviewImg.classList.add('hidden');
+    if (opPacking_removePhotoButton) opPacking_removePhotoButton.classList.add('hidden');
 }
 
 async function confirmPacking() {


### PR DESCRIPTION
## Summary
- add a **ลบรูป / ถ่ายใหม่** button to packing form
- allow every role to remove an uploaded image

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842c80509808324992ba67ef5b481fa