### PR TITLE
Fix camera stop on shipping scan cancel

### DIFF
--- a/js/operatorShippingPage.js
+++ b/js/operatorShippingPage.js
@@ -171,9 +171,15 @@ function startScanForBatch() {
     });
 }
 
-function stopScanForBatch() {
+async function stopScanForBatch() {
     if (html5QrScannerForBatch) {
-        html5QrScannerForBatch.stop().catch(e => console.warn("Error stopping batch scanner:", e));
+        try {
+            await html5QrScannerForBatch.stop();
+            await html5QrScannerForBatch.clear();
+        } catch (e) {
+            console.warn("Error stopping batch scanner:", e);
+        }
+        html5QrScannerForBatch = null;
     }
     uiElements.qrScannerContainer_Batch.classList.add('hidden');
     uiElements.stopScanForBatchButton.classList.add('hidden');


### PR DESCRIPTION
## Summary
- properly stop and clear the QR scanner when leaving shipping batch scans

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6842c8b6458083248f0097f3c90f1330