### PR TITLE
Fix Firebase query imports

### DIFF
--- a/js/operatorShippingPage.js
+++ b/js/operatorShippingPage.js
@@ -1,7 +1,7 @@
 // js/operatorShippingPage.js
 import { showPage, uiElements } from './ui.js';
 import { database, storage, auth } from './config.js';
-import { ref, set, get, update, serverTimestamp, push } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-database.js";
+import { ref, set, get, update, serverTimestamp, push, query, orderByChild, equalTo } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-database.js";
 import { ref as storageRefFirebase, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-storage.js"; // Renamed to avoid conflict
 import { showAppStatus } from './utils.js';
 import { getCurrentUser, getCurrentUserRole } from './auth.js';


### PR DESCRIPTION
## Summary
- fix missing imports for `query`, `orderByChild`, and `equalTo` in operator shipping page

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6842cabca86c8324b1d6d4dec076fc19