### PR TITLE
Add beep sounds on QR scan events

### DIFF
--- a/js/adminOrderPage.js
+++ b/js/adminOrderPage.js
@@ -2,7 +2,7 @@
 import { auth, database } from './config.js';
 import { ref, set, serverTimestamp, push } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-database.js";
 // import { uiElements, showPage } from './ui.js'; // <<<--- ลบออก
-import { detectPlatformFromPackageCode, setDefaultDueDate, showAppStatus } from './utils.js';
+import { detectPlatformFromPackageCode, setDefaultDueDate, showAppStatus, beepSuccess, beepError } from './utils.js';
 import { getCurrentUser, getCurrentUserRole } from './auth.js';
 import { loadOrderForAddingItems } from './adminItemsPage.js'; // This should also not rely on global uiElements from ui.js
 
@@ -92,16 +92,19 @@ function startPackageCodeScan() {
                 { deviceId: { exact: camId } },
                 { fps: 10, qrbox: { width: 250, height: 250 }, videoConstraints: { focusMode: "continuous", facingMode: "environment" } },
                 onScanSuccess_PackageCode,
-                (errorMessage) => { console.warn("Package Code Scan failure:", errorMessage); }
+                (errorMessage) => { console.warn("Package Code Scan failure:", errorMessage); beepError(); }
             ).catch(err => {
+                beepError();
                 alert("ไม่สามารถเปิดกล้องสแกน QR ได้: " + (err?.message || err));
                 stopPackageCodeScan();
             });
         } else {
+            beepError();
             alert("ไม่พบกล้องบนอุปกรณ์");
             stopPackageCodeScan();
         }
     }).catch(err => {
+        beepError();
         alert("ไม่สามารถเข้าถึงกล้อง: " + (err?.message || err));
         stopPackageCodeScan();
     });
@@ -124,6 +127,7 @@ async function stopPackageCodeScan() {
 }
 
 function onScanSuccess_PackageCode(decodedText, decodedResult) {
+    beepSuccess();
     const packageCode = decodedText.trim();
     if (adminOrderScannedQRData) adminOrderScannedQRData.textContent = packageCode;
     if (adminOrderPackageCodeInput) {
@@ -160,19 +164,23 @@ function startPlatformIdScan() {
                     formatsToSupport: [Html5QrcodeSupportedFormats.CODE_128]
                 },
                 (decodedText, decodedResult) => {
+                    beepSuccess();
                     adminOrderPlatformOrderIdInput.value = decodedText.trim();
                     stopPlatformIdScan();
                 },
-                (errorMessage) => { console.warn("Platform Order ID Scan failure:", errorMessage); }
+                (errorMessage) => { console.warn("Platform Order ID Scan failure:", errorMessage); beepError(); }
             ).catch(err => {
+                beepError();
                 alert("ไม่สามารถเปิดกล้องสแกน Platform Order ID ได้: " + (err?.message || err));
                 stopPlatformIdScan();
             });
         } else {
+            beepError();
             alert("ไม่พบกล้องบนอุปกรณ์");
             stopPlatformIdScan();
         }
     }).catch(err => {
+        beepError();
         alert("ไม่สามารถเข้าถึงกล้อง: " + (err?.message || err));
         stopPlatformIdScan();
     });

--- a/js/operatorShippingPage.js
+++ b/js/operatorShippingPage.js
@@ -3,7 +3,7 @@ import { showPage, uiElements } from './ui.js';
 import { database, storage, auth } from './config.js';
 import { ref, set, get, update, serverTimestamp, push, query, orderByChild, equalTo } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-database.js";
 import { ref as storageRefFirebase, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-storage.js"; // Renamed to avoid conflict
-import { showAppStatus } from './utils.js';
+import { showAppStatus, beepSuccess, beepError } from './utils.js';
 import { getCurrentUser, getCurrentUserRole } from './auth.js';
 
 let currentActiveBatchId = null; // Stores the ID of the batch currently being worked on
@@ -114,6 +114,7 @@ function startScanForBatch() {
             html5QrScannerForBatch.start(
                 { deviceId: { exact: camId } }, { fps: 10, qrbox: { width: 250, height: 250 } },
                 async (decodedText, decodedResult) => { // onScanSuccess
+            beepSuccess();
             const packageCodeScanned = decodedText.trim();
             console.log(`Scanned for batch: ${packageCodeScanned}`);
             // Find the order with this packageCode that is "Ready for Shipment" or similar
@@ -151,20 +152,23 @@ function startScanForBatch() {
             }
             // Scanner does not stop automatically here, user can scan multiple items
         },
-                (errorMessage) => { /* console.warn("Batch Scan failure:", errorMessage); */ }
+                (errorMessage) => { /* console.warn("Batch Scan failure:", errorMessage); */ beepError(); }
             ).catch(err => {
+                beepError();
                 alert("ไม่สามารถเปิดกล้องสแกน QR สำหรับ Batch ได้: " + (err?.message || err));
                 uiElements.qrScannerContainer_Batch.classList.add('hidden');
                 uiElements.stopScanForBatchButton.classList.add('hidden');
                 uiElements.startScanForBatchButton.disabled = false;
             });
         } else {
+            beepError();
             alert("ไม่พบกล้องบนอุปกรณ์");
             uiElements.qrScannerContainer_Batch.classList.add('hidden');
             uiElements.stopScanForBatchButton.classList.add('hidden');
             uiElements.startScanForBatchButton.disabled = false;
         }
     }).catch(err => {
+        beepError();
         alert("ไม่สามารถเข้าถึงกล้อง: " + (err?.message || err));
         uiElements.qrScannerContainer_Batch.classList.add('hidden');
         uiElements.stopScanForBatchButton.classList.add('hidden');

--- a/js/utils.js
+++ b/js/utils.js
@@ -33,6 +33,29 @@ export function detectPlatformFromPackageCode(packageCode) {
     return "Unknown";
 }
 
+// ---- Beep Utility Functions ----
+function playBeepSequence(times = 1) {
+    try {
+        const ctx = new (window.AudioContext || window.webkitAudioContext)();
+        for (let i = 0; i < times; i++) {
+            const osc = ctx.createOscillator();
+            const gain = ctx.createGain();
+            osc.type = 'sine';
+            osc.frequency.value = 800;
+            osc.connect(gain);
+            gain.connect(ctx.destination);
+            const startAt = ctx.currentTime + i * 0.25;
+            osc.start(startAt);
+            osc.stop(startAt + 0.15);
+        }
+    } catch (e) {
+        console.warn('playBeepSequence error:', e);
+    }
+}
+
+export function beepSuccess() { playBeepSequence(1); }
+export function beepError() { playBeepSequence(2); }
+
 /**
  * Sets the default due date for new orders in the adminDueDateInput field.
  * - If current time is 12:00 PM - 11:59 PM, sets to next day.
@@ -75,6 +98,7 @@ export function showAppStatus(message, type = 'info', appStatusElement) {
         appStatusElement.classList.add('success'); // Define .success in CSS
     } else if (type === 'error') {
         appStatusElement.classList.add('error');   // Define .error in CSS
+        beepError();
     } else {
         appStatusElement.classList.add('info');    // Define .info in CSS
     }


### PR DESCRIPTION
## Summary
- add web audio beep helpers
- beep twice on errors via `showAppStatus`
- beep on successful QR scans

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842cc34d97483248c0c81ce385c588f