### PR TITLE
Improve dashboard cards and shipping input

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -61,6 +61,7 @@ label { display: block; margin-bottom: 8px; font-weight: 600; color: #555; font-
 #photoPreview, #packingPhotoPreview { max-width:100%; max-height:250px; margin-top:10px; border:1px solid #dce4ec; display:block; border-radius: 8px; }
 
 .summary-card { background-color:#fff; border-radius:12px; padding:20px; box-shadow: 0 2px 8px rgba(0,0,0,0.07); flex: 1; min-width: 160px; text-align:left; border-left: 5px solid #3498db; }
+.summary-card.clickable { cursor:pointer; }
 .summary-card-icon { font-size: 1.8em; margin-bottom: 10px; color: #3498db; float:right; }
 .summary-card-value { margin:0 0 5px 0; font-size:2em; font-weight:bold; color: #2c3e50;}
 .summary-card-title { margin:0; color:#7f8c8d; font-size:0.95em;}

--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
                     <button id="startScanForBatchButton" type="button">สแกน QR พัสดุ</button>
 
                     <div class="input-group" style="margin-top:10px;">
-                        <input type="text" id="manualBatchPackageInput" list="readyToShipDatalist" placeholder="พิมพ์รหัสพัสดุ" autocomplete="off">
+                        <input type="text" id="manualBatchPackageInput" placeholder="พิมพ์รหัสพัสดุ" autocomplete="off">
                         <datalist id="readyToShipDatalist"></datalist>
                         <button id="addManualPackageButton" type="button" class="secondary" style="width:auto;">เพิ่ม</button>
                     </div>

--- a/js/dashboardPage.js
+++ b/js/dashboardPage.js
@@ -3,6 +3,7 @@ import { database } from './config.js';
 import { ref, get, update, remove, serverTimestamp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-database.js";
 import { showAppStatus } from './utils.js';
 import { getCurrentUser, getCurrentUserRole } from './auth.js';
+import { showPage } from './ui.js';
 // ไม่ต้อง import uiElements จาก ui.js แล้ว
 
 let dailyChartInstance = null;
@@ -94,18 +95,29 @@ function updateSummaryCards(orders) {
     if (!el_summaryCardsContainer) return;
     el_summaryCardsContainer.innerHTML = '';
     const total = orders.length;
-    const shipped = orders.filter(o => o.status === "Shipped" || o.status === "Shipment Approved").length;
-    const pending = orders.filter(o => o.status === "Ready for Shipment" || o.status === "Pending Supervisor Ship Check").length;
+    const readyToPack = orders.filter(o => o.status === 'Ready to Pack').length;
+    const pendingCheck = orders.filter(o => o.status === 'Pending Supervisor Pack Check').length;
+    const readyToShip = orders.filter(o => o.status === 'Ready for Shipment' || o.status === 'Pack Approved').length;
+    const shipped = orders.filter(o => o.status === 'Shipped' || o.status === 'Shipment Approved').length;
+
     const todayStr = new Date().toISOString().slice(0, 10);
     const todayOrders = orders.filter(o => o.createdAt && typeof o.createdAt === 'number' && new Date(o.createdAt).toISOString().slice(0, 10) === todayStr).length;
-    createSummaryCard("พัสดุทั้งหมด", total, `+${todayOrders} วันนี้`, "📦");
-    createSummaryCard("ส่งแล้ว", shipped, total > 0 ? `${Math.round((shipped / total) * 100)}%` : "0%", "✅");
-    createSummaryCard("รอส่ง", pending, total > 0 ? `${Math.round((pending / total) * 100)}%` : "0%", "⏰");
+
+    createSummaryCard('พัสดุทั้งหมด', total, `+${todayOrders} วันนี้`, '📦');
+    createSummaryCard('รายการรอแพ็ก', readyToPack, total > 0 ? `${Math.round((readyToPack/total)*100)}%` : '0%', '📋', 'operatorTaskListPage');
+    createSummaryCard('รอตรวจเช็ค', pendingCheck, total > 0 ? `${Math.round((pendingCheck/total)*100)}%` : '0%', '🕵️', 'supervisorPackCheckListPage');
+    createSummaryCard('เตรียมส่ง', readyToShip, total > 0 ? `${Math.round((readyToShip/total)*100)}%` : '0%', '🚚', 'operatorShippingBatchPage');
+    createSummaryCard('ส่งแล้ว', shipped, total > 0 ? `${Math.round((shipped/total)*100)}%` : '0%', '✅');
 }
 
-function createSummaryCard(title, value, subValue, icon) {
+function createSummaryCard(title, value, subValue, icon, pageId = null) {
     if (!el_summaryCardsContainer) return;
-    const card = document.createElement('div'); card.className = 'summary-card';
+    const card = document.createElement('div');
+    card.className = 'summary-card';
+    if (pageId) {
+        card.classList.add('clickable');
+        card.addEventListener('click', () => showPage(pageId));
+    }
     card.innerHTML = `<div class="summary-card-icon">${icon}</div><h4 class="summary-card-value">${value}</h4><p class="summary-card-title">${title}</p><p class="summary-card-subvalue">${subValue}</p>`;
     el_summaryCardsContainer.appendChild(card);
 }


### PR DESCRIPTION
## Summary
- reorder dashboard summary cards
- make summary cards clickable to navigate to other pages
- remove datalist dropdown on manual package input

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68432f1234e08324b17c5a58e29b1dce