### PR TITLE
Improve mobile icon sizes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -53,7 +53,7 @@ label { display: block; margin-bottom: 8px; font-weight: 600; color: #555; font-
     background:none;
     color: #ecf0f1;
     padding: 10px 8px;
-    font-size:0.8em;
+    font-size:0.85em;
     border:none;
     opacity: 0.8;
     display:flex;
@@ -61,7 +61,7 @@ label { display: block; margin-bottom: 8px; font-weight: 600; color: #555; font-
     align-items:center;
 }
 .bottom-nav button.active { color: #3498db; font-weight:bold; opacity: 1; }
-.bottom-nav button .nav-icon { font-size:1.2em; line-height:1; }
+.bottom-nav button .nav-icon { font-size:1.6em; line-height:1; }
 .material-icons.nav-icon { vertical-align: middle; }
 
 .item-checklist { list-style-type: none; padding-left: 0; }
@@ -73,7 +73,13 @@ label { display: block; margin-bottom: 8px; font-weight: 600; color: #555; font-
 
 .summary-card { background-color:#fff; border-radius:12px; padding:20px; box-shadow: 0 2px 8px rgba(0,0,0,0.07); flex: 1; min-width: 160px; text-align:left; border-left: 5px solid #3498db; }
 .summary-card.clickable { cursor:pointer; }
-.summary-card-icon { font-size: 1.8em; margin-bottom: 10px; color: #3498db; float:right; }
+.summary-card-icon {
+    font-size: 3.5em;
+    margin-bottom: 10px;
+    color: #3498db;
+    float: right;
+    line-height: 1;
+}
 .summary-card-icon.material-icons { vertical-align: middle; }
 .summary-card-value { margin:0 0 5px 0; font-size:2em; font-weight:bold; color: #2c3e50;}
 .summary-card-title { margin:0; color:#7f8c8d; font-size:0.95em;}
@@ -112,4 +118,24 @@ tbody tr:hover { background-color: #f1f8ff; }
     justify-content: center;
     align-items: center;
     z-index: 2000;
+}
+
+/* Responsive icon and text sizing */
+.bottom-nav button {
+    font-size: 0.85em;
+}
+
+@media (min-width: 600px) {
+    .bottom-nav button {
+        font-size: 1em;
+    }
+    .bottom-nav button .nav-icon {
+        font-size: 2em;
+    }
+    .summary-card-icon {
+        font-size: 4.5em;
+    }
+    .summary-card-value {
+        font-size: 2.2em;
+    }
 }


### PR DESCRIPTION
## Summary
- resize dashboard icons in navigation and summary cards
- add responsive styling for fonts and icons
- enlarge dashboard summary card icons

## Testing
- `npx --version`

------
https://chatgpt.com/codex/tasks/task_e_684345f5c56083249440ad93185c63e0