### PR TITLE
Add packing checklist checkboxes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -68,6 +68,11 @@ label { display: block; margin-bottom: 8px; font-weight: 600; color: #555; font-
 .item-checklist li { padding: 8px 0; border-bottom: 1px dashed #ecf0f1; font-size: 0.95em; display: flex; justify-content: space-between; align-items: center;}
 .item-checklist li:last-child { border-bottom: none; }
 
+/* Checklist styles for packing page */
+.packing-checklist li { font-size: 1.1em; }
+.item-checklist input[type="checkbox"] { transform: scale(1.3); margin-right: 10px; }
+.item-checklist li.checked label { text-decoration: line-through; color: #888; }
+
 .qr-scanner-area { width: 100%; max-width:350px; border:2px dashed #3498db; margin:10px auto; padding:5px; background-color: #f9f9f9; border-radius: 8px;}
 #photoPreview, #packingPhotoPreview { max-width:100%; max-height:250px; margin-top:10px; border:1px solid #dce4ec; display:block; border-radius: 8px; }
 

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
                 <p><strong>Platform:</strong> <span id="packOrderPlatform"></span></p>
                 <p><strong>Due Date:</strong> <span id="packOrderDueDate"></span></p>
                 <h3>Checklist รายการสินค้า:</h3>
-                <ul id="packOrderItemList" class="item-checklist"></ul>
+                <ul id="packOrderItemList" class="item-checklist packing-checklist"></ul>
                 <label for="packingPhoto">ถ่ายรูปสินค้าที่เตรียม:</label>
                 <input type="file" id="packingPhoto" accept="image/*" capture="environment">
                 <img id="packingPhotoPreview" src="#" alt="Preview" class="hidden">

--- a/js/operatorPackingPage.js
+++ b/js/operatorPackingPage.js
@@ -82,7 +82,19 @@ export async function loadOrderForPacking(orderKey) {
                 for (const itemId in orderData.items) {
                     const item = orderData.items[itemId];
                     const li = document.createElement('li');
-                    li.textContent = `${item.productName} - ${item.quantity} ${item.unit}`;
+                    const label = document.createElement('label');
+                    const cb = document.createElement('input');
+                    cb.type = 'checkbox';
+                    cb.addEventListener('change', () => {
+                        if (cb.checked) {
+                            li.classList.add('checked');
+                        } else {
+                            li.classList.remove('checked');
+                        }
+                    });
+                    label.appendChild(cb);
+                    label.appendChild(document.createTextNode(` ${item.productName} - ${item.quantity} ${item.unit}`));
+                    li.appendChild(label);
                     if(opPacking_itemListUL) opPacking_itemListUL.appendChild(li);
                 }
             }


### PR DESCRIPTION
## Summary
- add packing checklist checkboxes with label for operator
- adjust packing page markup to use new style
- style checklist items and highlight checked state

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843d354ceb88324938439f73af5e067