### PR TITLE
Fix due date editing on dashboard

### DIFF
--- a/js/dashboardPage.js
+++ b/js/dashboardPage.js
@@ -221,7 +221,13 @@ async function handleEditOrder(orderKey) {
 
     const dueDateInput = document.createElement('input');
     dueDateInput.type = 'date';
-    dueDateInput.value = formatDateYYYYMMDD(row.dataset.duedate);
+    const dueDateVal = row.dataset.duedate;
+    if (dueDateVal) {
+        const ts = parseInt(dueDateVal, 10);
+        if (!isNaN(ts)) {
+            dueDateInput.value = formatDateYYYYMMDD(ts);
+        }
+    }
 
     platformOrderCell.innerHTML = '';
     packageCodeCell.innerHTML = '';


### PR DESCRIPTION
## Summary
- ensure due date is parsed as a number when editing orders

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844788ff5ac8324a37c8c575a2b8735