### PR TITLE
Fix default status when editing orders

### DIFF
--- a/js/dashboardPage.js
+++ b/js/dashboardPage.js
@@ -153,6 +153,7 @@ function updateOrdersLogTable(orders, filterStatus = 'all', searchCode = '') {
         const r = el_ordersTableBody.insertRow();
         r.dataset.orderkey = o.key;
         r.dataset.duedate = o.dueDate || '';
+        r.dataset.status = o.status || '';
         r.insertCell().textContent = o.packageCode || 'N/A';
         r.insertCell().textContent = o.platformOrderId || '-';
         r.insertCell().textContent = o.platform || 'N/A';
@@ -217,7 +218,8 @@ async function handleEditOrder(orderKey) {
         opt.textContent = text;
         statusSelect.appendChild(opt);
     });
-    statusSelect.value = statusCell.textContent.trim();
+    const currentStatus = row.dataset.status || statusCell.textContent.trim();
+    statusSelect.value = currentStatus;
 
     const dueDateInput = document.createElement('input');
     dueDateInput.type = 'date';


### PR DESCRIPTION
## Summary
- keep the original status value on each row
- load that value when editing so the dropdown shows the current status

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68447a7740c48324bdc418a58e6d4946