### PR TITLE
Add popup feedback after QR scan

### DIFF
--- a/js/adminOrderPage.js
+++ b/js/adminOrderPage.js
@@ -127,7 +127,6 @@ async function stopPackageCodeScan() {
 }
 
 function onScanSuccess_PackageCode(decodedText, decodedResult) {
-    beepSuccess();
     const packageCode = decodedText.trim();
     if (adminOrderScannedQRData) adminOrderScannedQRData.textContent = packageCode;
     if (adminOrderPackageCodeInput) {
@@ -140,6 +139,7 @@ function onScanSuccess_PackageCode(decodedText, decodedResult) {
     if (adminOrderPlatformOrderIdInput && !adminOrderPlatformOrderIdInput.value.trim()) {
         adminOrderPlatformOrderIdInput.focus();
     }
+    beepSuccess();
     stopPackageCodeScan();
 }
 
@@ -164,8 +164,8 @@ function startPlatformIdScan() {
                     formatsToSupport: [Html5QrcodeSupportedFormats.CODE_128]
                 },
                 (decodedText, decodedResult) => {
-                    beepSuccess();
                     adminOrderPlatformOrderIdInput.value = decodedText.trim();
+                    beepSuccess();
                     stopPlatformIdScan();
                 },
                 (errorMessage) => { console.warn("Platform Order ID Scan failure:", errorMessage); beepError(); }

--- a/js/operatorShippingPage.js
+++ b/js/operatorShippingPage.js
@@ -139,7 +139,6 @@ function startScanForBatch() {
             html5QrScannerForBatch.start(
                 { deviceId: { exact: camId } }, { fps: 10, qrbox: { width: 250, height: 250 } },
                 async (decodedText, decodedResult) => { // onScanSuccess
-            beepSuccess();
             const packageCodeScanned = decodedText.trim();
             console.log(`Scanned for batch: ${packageCodeScanned}`);
             // Find the order with this packageCode that is "Ready for Shipment" or similar
@@ -172,6 +171,7 @@ function startScanForBatch() {
                     renderBatchItems();
                     showAppStatus(`เพิ่ม ${packageCodeScanned} เข้า Batch สำเร็จ`, 'success', uiElements.appStatus);
                 }
+                beepSuccess();
             } else {
                 showAppStatus(`ไม่พบออเดอร์ที่พร้อมส่งสำหรับรหัสพัสดุ: ${packageCodeScanned} หรือสถานะไม่ถูกต้อง`, "error", uiElements.appStatus);
             }

--- a/js/utils.js
+++ b/js/utils.js
@@ -33,28 +33,14 @@ export function detectPlatformFromPackageCode(packageCode) {
     return "Unknown";
 }
 
-// ---- Beep Utility Functions ----
-function playBeepSequence(times = 1) {
-    try {
-        const ctx = new (window.AudioContext || window.webkitAudioContext)();
-        for (let i = 0; i < times; i++) {
-            const osc = ctx.createOscillator();
-            const gain = ctx.createGain();
-            osc.type = 'sine';
-            osc.frequency.value = 800;
-            osc.connect(gain);
-            gain.connect(ctx.destination);
-            const startAt = ctx.currentTime + i * 0.25;
-            osc.start(startAt);
-            osc.stop(startAt + 0.15);
-        }
-    } catch (e) {
-        console.warn('playBeepSequence error:', e);
-    }
+// ---- Scan Feedback Utility Functions ----
+export function beepSuccess() {
+    alert('การอ่านค่าสำเร็จ');
 }
 
-export function beepSuccess() { playBeepSequence(1); }
-export function beepError() { playBeepSequence(2); }
+export function beepError() {
+    // No sound; reserved for future visual feedback if needed
+}
 
 /**
  * Sets the default due date for new orders in the adminDueDateInput field.


### PR DESCRIPTION
## Summary
- remove beep tone utility and show popup instead
- trigger popup after scan data is filled

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68448e7028388324aa18453a1480c23f