### PR TITLE
Add due-today dashboard table and photo upload choice

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -229,3 +229,8 @@ tbody tr:hover { background-color: #f1f8ff; }
 .toast.success { background-color: var(--primary-green); }
 .toast.error { background-color: #e74c3c; }
 
+
+/* Urgent due today table styles */
+#dueTodayTableContainer thead tr { background-color: #ffe5e5; }
+.due-today-row { background-color: #fff0f0; }
+

--- a/delivery.html
+++ b/delivery.html
@@ -37,6 +37,15 @@
                     <h3 style="margin-top:20px;">สถิติตามแพลตฟอร์ม</h3>
                     <div style="height:280px; max-width:400px; margin:auto;"><canvas id="platformStatsChart"></canvas></div>
                 </div>
+                <div id="dueTodayContainer" style="margin-bottom:20px;">
+                    <h3>รายการครบกำหนดวันนี้</h3>
+                    <div id="dueTodayTableContainer" style="max-height:300px; overflow-y:auto; border:1px solid #ccc;">
+                        <table><thead><tr style="background-color:#ffe5e5;">
+                            <th>Package Code</th><th>Platform Order ID</th><th>Platform</th><th>สถานะ</th><th>Created At</th><th>Due Date</th><th>Actions</th>
+                        </tr></thead><tbody id="dueTodayTableBody"></tbody></table>
+                    </div>
+                    <p id="noDueTodayMessage" class="hidden" style="text-align:center; padding:20px;">ไม่มีรายการครบกำหนดวันนี้</p>
+                </div>
                 <div id="ordersLogContainer">
                     <h3>ประวัติพัสดุล่าสุด</h3>
                     <div style="display:flex; gap:10px; margin-bottom:10px; align-items:center;">
@@ -119,8 +128,8 @@
                 <p><strong>Due Date:</strong> <span id="packOrderDueDate"></span></p>
                 <h3>Checklist รายการสินค้า:</h3>
                 <ul id="packOrderItemList" class="item-checklist packing-checklist"></ul>
-                <label for="packingPhoto">ถ่ายรูปสินค้าที่เตรียม:</label>
-                <input type="file" id="packingPhoto" accept="image/*" capture="environment">
+                <label for="packingPhoto">ถ่ายหรือเลือกรูปสินค้าที่เตรียม:</label>
+                <input type="file" id="packingPhoto" accept="image/*" >
                 <img id="packingPhotoPreview" src="#" alt="Preview" class="hidden">
                 <button id="removePackingPhotoButton" type="button" class="secondary hidden" style="width:auto; margin-top:10px;">ลบรูป / ถ่ายใหม่</button>
                 <label for="operatorPackNotes">หมายเหตุ (ถ้ามี):</label>
@@ -197,8 +206,8 @@
                 <p><strong>Courier:</strong> <span id="confirmShipCourierDisplay"></span></p>
                 <p><strong>จำนวนพัสดุ:</strong> <span id="confirmShipItemCountDisplay"></span> รายการ</p>
                 <div class="form-group">
-                    <label for="shipmentGroupPhoto">ถ่ายรูปรวมพัสดุที่ส่ง:</label>
-                    <input type="file" id="shipmentGroupPhoto" accept="image/*" capture="environment">
+                    <label for="shipmentGroupPhoto">ถ่ายหรือเลือกรูปรวมพัสดุที่ส่ง:</label>
+                    <input type="file" id="shipmentGroupPhoto" accept="image/*" >
                     <img id="shipmentGroupPhotoPreview" src="#" alt="Preview รูปรวม" class="hidden">
                 </div>
                 <div class="form-group hidden">

--- a/js/dashboardPage.js
+++ b/js/dashboardPage.js
@@ -14,6 +14,7 @@ let el_appStatus, el_currentDateDisplay, el_refreshDashboardButton,
     el_summaryCardsContainer, el_dailyStatsCanvas, el_platformStatsCanvas,
     el_logFilterSelect, el_applyLogFilterButton, el_logSearchInput,
     el_ordersTableBody, el_noOrdersMessage;
+    el_dueTodayTableBody, el_noDueTodayMessage;
 
 export function initializeDashboardPageListeners() {
     // Query for elements specific to this page when listeners are set up
@@ -28,6 +29,8 @@ export function initializeDashboardPageListeners() {
     el_logSearchInput = document.getElementById('logSearchPackageCode');
     el_ordersTableBody = document.getElementById('ordersTableBody');
     el_noOrdersMessage = document.getElementById('noOrdersMessage');
+    el_dueTodayTableBody = document.getElementById("dueTodayTableBody");
+    el_noDueTodayMessage = document.getElementById("noDueTodayMessage");
 
     if (el_refreshDashboardButton) {
         el_refreshDashboardButton.addEventListener('click', () => loadDashboardData(el_logFilterSelect ? el_logFilterSelect.value : 'all', el_logSearchInput ? el_logSearchInput.value.trim() : ''));
@@ -52,6 +55,17 @@ export function initializeDashboardPageListeners() {
                 const key = e.target.dataset.orderkey;
                 if (key) handleEditOrder(key);
             } else if (e.target.classList.contains('delete-order-btn')) {
+                const key = e.target.dataset.orderkey;
+                if (key) handleDeleteOrder(key);
+            }
+        });
+    }
+    if (el_dueTodayTableBody) {
+        el_dueTodayTableBody.addEventListener("click", (e) => {
+            if (e.target.classList.contains("edit-order-btn")) {
+                const key = e.target.dataset.orderkey;
+                if (key) handleEditOrder(key);
+            } else if (e.target.classList.contains("delete-order-btn")) {
                 const key = e.target.dataset.orderkey;
                 if (key) handleDeleteOrder(key);
             }
@@ -87,6 +101,7 @@ export async function loadDashboardData(filterStatus = 'all', searchCode = '') {
         }
 
         updateSummaryCards(allOrders);
+        updateDueTodayTable(allOrders);
         updateOrdersLogTable(allOrders, filterStatus, searchCode);
         renderCharts(allOrders);
 
@@ -139,6 +154,51 @@ function createSummaryCard(title, value, subValue, icon, pageId = null) {
     }
     card.innerHTML = `<div class="summary-card-icon material-icons">${icon}</div><h4 class="summary-card-value">${value}</h4><p class="summary-card-title">${title}</p><p class="summary-card-subvalue">${subValue}</p>`;
     el_summaryCardsContainer.appendChild(card);
+}
+
+function updateDueTodayTable(orders) {
+    if (!el_dueTodayTableBody) return;
+    el_dueTodayTableBody.innerHTML = '';
+    const todayStr = new Date().toISOString().slice(0, 10);
+    const dueToday = orders.filter(o => o.dueDate && new Date(o.dueDate).toISOString().slice(0, 10) === todayStr);
+    if (dueToday.length === 0) {
+        const r = el_dueTodayTableBody.insertRow();
+        const c = r.insertCell();
+        c.colSpan = 7;
+        c.textContent = 'ไม่พบข้อมูล';
+        c.style.textAlign = 'center';
+        c.style.padding = '20px';
+        if (el_noDueTodayMessage) el_noDueTodayMessage.classList.remove('hidden');
+        return;
+    }
+    if (el_noDueTodayMessage) el_noDueTodayMessage.classList.add('hidden');
+    const role = getCurrentUserRole();
+    dueToday.forEach(o => {
+        const r = el_dueTodayTableBody.insertRow();
+        r.classList.add('due-today-row');
+        r.dataset.orderkey = o.key;
+        r.insertCell().textContent = o.packageCode || 'N/A';
+        r.insertCell().textContent = o.platformOrderId || '-';
+        r.insertCell().textContent = o.platform || 'N/A';
+        r.insertCell().textContent = translateStatusToThai(o.status);
+        r.insertCell().textContent = formatDateTimeDDMMYYYYHHMM(o.createdAt);
+        r.insertCell().textContent = formatDateDDMMYYYY(o.dueDate);
+        const actCell = r.insertCell();
+        if (role === 'administrator' || role === 'supervisor') {
+            const btn = document.createElement('button');
+            btn.textContent = 'แก้ไข';
+            btn.className = 'edit-order-btn';
+            btn.dataset.orderkey = o.key;
+            actCell.appendChild(btn);
+            const delBtn = document.createElement('button');
+            delBtn.textContent = 'ลบ';
+            delBtn.className = 'delete-order-btn';
+            delBtn.dataset.orderkey = o.key;
+            actCell.appendChild(delBtn);
+        } else {
+            actCell.textContent = '-';
+        }
+    });
 }
 
 function updateOrdersLogTable(orders, filterStatus = 'all', searchCode = '') {


### PR DESCRIPTION
## Summary
- show orders due today in a new table at the top of dashboard
- highlight rows with urgent styling
- allow choosing existing photos instead of only taking a new picture

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845a4abfbb08324a6d4251c2166b1c9