### PR TITLE
Fix due today element declaration

### DIFF
--- a/js/dashboardPage.js
+++ b/js/dashboardPage.js
@@ -13,7 +13,7 @@ let platformChartInstance = null;
 let el_appStatus, el_currentDateDisplay, el_refreshDashboardButton,
     el_summaryCardsContainer, el_dailyStatsCanvas, el_platformStatsCanvas,
     el_logFilterSelect, el_applyLogFilterButton, el_logSearchInput,
-    el_ordersTableBody, el_noOrdersMessage;
+    el_ordersTableBody, el_noOrdersMessage,
     el_dueTodayTableBody, el_noDueTodayMessage;
 
 export function initializeDashboardPageListeners() {


### PR DESCRIPTION
## Summary
- fix dashboard element declaration for due today table

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845ad6ba9788324b3ed61b02fc0b44c