### PR TITLE
Improve multiple image preview

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -97,6 +97,8 @@ label { display: block; margin-bottom: 8px; font-weight: 600; color: #555; font-
 .qr-scanner-area { width: 100%; max-width:350px; border:2px dashed var(--primary-blue); margin:10px auto; padding:5px; background-color: #f9f9f9; border-radius: 8px; }
 #photoPreview, #packingPhotoPreviewContainer img, #checkOrderPackingPhotoContainer img { max-width:100%; max-height:250px; margin-top:10px; border:1px solid #dce4ec; display:block; border-radius: 8px; }
 #packingPhotoPreviewContainer, #checkOrderPackingPhotoContainer { display:flex; flex-wrap:wrap; gap:10px; }
+.photo-thumb { position: relative; display:inline-block; }
+.remove-photo-btn { position:absolute; top:2px; right:2px; background:rgba(0,0,0,0.6); color:#fff; border:none; border-radius:50%; width:20px; height:20px; line-height:18px; cursor:pointer; font-size:14px; }
 #shipmentGroupPhotoPreview { max-width:100%; max-height:250px; margin-top:10px; border:1px solid #dce4ec; display:block; border-radius: 8px; }
 
 .summary-card { background-color:#fff; border-radius:12px; padding:20px; box-shadow: 0 2px 8px rgba(0,0,0,0.07); flex: 1; min-width: 160px; text-align:left; border-left: 5px solid var(--primary-blue); }

--- a/js/operatorPackingPage.js
+++ b/js/operatorPackingPage.js
@@ -153,9 +153,27 @@ function displayPackingPhotoPreviews() {
     if (!opPacking_photoPreviewContainer) return;
     opPacking_photoPreviewContainer.innerHTML = '';
     packingPhotoFiles.forEach((file, idx) => {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'photo-thumb';
+
         const img = document.createElement('img');
         img.src = URL.createObjectURL(file);
-        opPacking_photoPreviewContainer.appendChild(img);
+        img.onload = () => URL.revokeObjectURL(img.src);
+        wrapper.appendChild(img);
+
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'remove-photo-btn';
+        removeBtn.textContent = '×';
+        removeBtn.addEventListener('click', () => {
+            packingPhotoFiles.splice(idx, 1);
+            displayPackingPhotoPreviews();
+            if (packingPhotoFiles.length === 0 && opPacking_removePhotoButton)
+                opPacking_removePhotoButton.classList.add('hidden');
+        });
+        wrapper.appendChild(removeBtn);
+
+        opPacking_photoPreviewContainer.appendChild(wrapper);
     });
     if (packingPhotoFiles.length > 0) {
         opPacking_photoPreviewContainer.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- show removable thumbnails for packing photo previews
- add small CSS helpers for preview thumbnails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68464d6189cc83248a8d2e175396bb9f