### PR TITLE
Show previous packing photos when repacking

### DIFF
--- a/delivery.html
+++ b/delivery.html
@@ -131,7 +131,6 @@
                 <label for="packingPhoto">ถ่ายหรือเลือกรูปสินค้าที่เตรียม:</label>
                 <input type="file" id="packingPhoto" accept="image/*" multiple>
                 <div id="packingPhotoPreviewContainer" class="hidden" style="display:flex; gap:10px; flex-wrap:wrap;"></div>
-                <button id="removePackingPhotoButton" type="button" class="secondary hidden" style="width:auto; margin-top:10px;">ลบรูป / ถ่ายใหม่</button>
                 <label for="operatorPackNotes">หมายเหตุ (ถ้ามี):</label>
                 <textarea id="operatorPackNotes"></textarea>
                 <button id="confirmPackingButton" type="button">ยืนยันการแพ็ก</button>


### PR DESCRIPTION
## Summary
- remove bulk delete photo button
- allow operator packing page to display previously uploaded photos
- allow removing individual existing or new photos
- keep all remaining and newly uploaded photos when confirming packing

## Testing
- `node --check js/operatorPackingPage.js`

------
https://chatgpt.com/codex/tasks/task_e_6846578e86cc83249211bbe1c6e52e7b