### PR TITLE
Implement shipped orders list and rear camera default

### DIFF
--- a/delivery.html
+++ b/delivery.html
@@ -258,6 +258,24 @@
                     </div>
                 </div>
             </div>
+
+            <!-- Shipped Orders List Page -->
+            <div id="shippedOrdersPage" class="container page hidden">
+                <h2>รายการที่ส่งแล้ว</h2>
+                <button id="refreshShippedOrders" type="button" class="secondary" style="width:auto; margin-bottom:15px;">รีเฟรช</button>
+                <div id="shippedOrdersListContainer">
+                    <p>กำลังโหลด...</p>
+                </div>
+                <p id="noShippedOrdersMessage" class="hidden">ไม่พบพัสดุที่ส่งแล้ว</p>
+            </div>
+
+            <!-- Shipped Order Detail Page -->
+            <div id="shippedOrderDetailPage" class="container page hidden">
+                <h2>รายละเอียดพัสดุที่ส่งแล้ว (Package Code: <span id="detailPackageCode"></span>)</h2>
+                <div id="shippedOrderDetailInfo"></div>
+                <button id="confirmShipmentButton" type="button" style="margin-top:15px;">ยืนยันความถูกต้อง</button>
+                <button id="backToShippedListButton" type="button" class="secondary" style="margin-top:10px;">กลับ</button>
+            </div>
             
             <p id="appStatus" style="text-align:center; padding:10px; font-size:0.9em;"></p>
         </div>

--- a/js/dashboardPage.js
+++ b/js/dashboardPage.js
@@ -137,7 +137,7 @@ function updateSummaryCards(orders) {
     createSummaryCard('รายการรอแพ็ก', readyToPack, total > 0 ? `${Math.round((readyToPack/total)*100)}%` : '0%', 'list_alt', 'operatorTaskListPage');
     createSummaryCard('รอตรวจเช็ค', pendingCheck, total > 0 ? `${Math.round((pendingCheck/total)*100)}%` : '0%', 'fact_check', 'supervisorPackCheckListPage');
     createSummaryCard('เตรียมส่ง', readyToShip, total > 0 ? `${Math.round((readyToShip/total)*100)}%` : '0%', 'local_shipping', 'operatorShippingBatchPage');
-    createSummaryCard('ส่งแล้ว', shipped, total > 0 ? `${Math.round((shipped/total)*100)}%` : '0%', 'check_circle');
+    createSummaryCard('ส่งแล้ว', shipped, total > 0 ? `${Math.round((shipped/total)*100)}%` : '0%', 'check_circle', 'shippedOrdersPage');
     if (typeof window.setNavBadgeCount === 'function') {
         window.setNavBadgeCount('operatorTaskListPage', readyToPack);
         window.setNavBadgeCount('supervisorPackCheckListPage', pendingCheck);

--- a/js/main.js
+++ b/js/main.js
@@ -11,7 +11,8 @@ import { initializeOperatorPackingPageListeners, loadOrderForPacking as operator
 import { initializeDashboardPageListeners, updateCurrentDateOnDashboard, loadDashboardData } from './dashboardPage.js';
 import { initializeSupervisorPackCheckListeners, loadOrdersForPackCheck } from './supervisorPackCheckPage.js';
 import { initializeOperatorTasksPageListeners, loadOperatorPendingTasks } from './operatorTasksPage.js';
-import { initializeOperatorShippingPageListeners, setupShippingBatchPage } from './operatorShippingPage.js'; 
+import { initializeOperatorShippingPageListeners, setupShippingBatchPage } from './operatorShippingPage.js';
+import { initializeShippedOrdersPageListeners, loadShippedOrders } from './shippedOrdersPage.js';
 
 window.currentUserFromAuth = null; 
 window.currentUserRoleFromAuth = null;
@@ -80,6 +81,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initializeSupervisorPackCheckListeners();
     initializeOperatorTasksPageListeners();
     initializeOperatorShippingPageListeners();
+    initializeShippedOrdersPageListeners();
     
     console.log("Initial event listeners set up (main.js)");
 
@@ -89,6 +91,7 @@ document.addEventListener('DOMContentLoaded', () => {
     window.loadOrdersForPackCheckGlobal = loadOrdersForPackCheck;
     window.loadOperatorPendingTasksGlobal = loadOperatorPendingTasks;
     window.setupShippingBatchPageGlobal = setupShippingBatchPage;
+    window.loadShippedOrdersGlobal = loadShippedOrders;
     window.loadOrderForPacking = operatorLoadOrderForPacking;
     window.loadOrderForAddingItems = loadOrderForAddingItems;
 

--- a/js/operatorShippingPage.js
+++ b/js/operatorShippingPage.js
@@ -135,7 +135,9 @@ function startScanForBatch() {
     }
     Html5Qrcode.getCameras().then(cameras => {
         if (cameras && cameras.length) {
-            const camId = cameras[0].id;
+            let cam = cameras.find(c => /back|rear|environment/i.test(c.label));
+            if (!cam) cam = cameras[cameras.length - 1];
+            const camId = cam.id;
             html5QrScannerForBatch.start(
                 { deviceId: { exact: camId } }, { fps: 10, qrbox: { width: 250, height: 250 } },
                 async (decodedText, decodedResult) => { // onScanSuccess

--- a/js/operatorTasksPage.js
+++ b/js/operatorTasksPage.js
@@ -176,7 +176,9 @@ function startScanForPacking() {
     }
     Html5Qrcode.getCameras().then(cameras => {
         if (cameras && cameras.length) {
-            const camId = cameras[0].id;
+            let cam = cameras.find(c => /back|rear|environment/i.test(c.label));
+            if (!cam) cam = cameras[cameras.length - 1];
+            const camId = cam.id;
             html5QrScannerForPacking.start(
                 { deviceId: { exact: camId } }, { fps: 10, qrbox: { width: 250, height: 250 } },
                 onPackingScanSuccess,

--- a/js/shippedOrdersPage.js
+++ b/js/shippedOrdersPage.js
@@ -1,0 +1,122 @@
+// js/shippedOrdersPage.js
+import { database } from './config.js';
+import { ref, query, orderByChild, equalTo, get, update, serverTimestamp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-database.js";
+import { showPage } from './ui.js';
+import { showAppStatus, formatDateDDMMYYYY, formatDateTimeDDMMYYYYHHMM } from './utils.js';
+import { getCurrentUser, getCurrentUserRole } from './auth.js';
+
+let currentDetailOrderKey = null;
+
+export function initializeShippedOrdersPageListeners() {
+    const refreshBtn = document.getElementById('refreshShippedOrders');
+    if (refreshBtn) refreshBtn.addEventListener('click', loadShippedOrders);
+
+    const backBtn = document.getElementById('backToShippedListButton');
+    if (backBtn) backBtn.addEventListener('click', () => showPage('shippedOrdersPage'));
+
+    const confirmBtn = document.getElementById('confirmShipmentButton');
+    if (confirmBtn) confirmBtn.addEventListener('click', confirmShipmentAdmin);
+}
+
+export async function loadShippedOrders() {
+    const listContainer = document.getElementById('shippedOrdersListContainer');
+    const noMsg = document.getElementById('noShippedOrdersMessage');
+    const appStatus = document.getElementById('appStatus');
+    if (!listContainer || !noMsg || !appStatus) return;
+
+    showAppStatus('กำลังโหลดรายการที่ส่งแล้ว...', 'info', appStatus);
+    listContainer.innerHTML = '<p style="text-align:center; padding:15px;">กำลังโหลด...</p>';
+    noMsg.classList.add('hidden');
+
+    try {
+        const q = query(ref(database, 'orders'), orderByChild('status'), equalTo('Shipped'));
+        const snap = await get(q);
+        listContainer.innerHTML = '';
+        let count = 0;
+        if (snap.exists()) {
+            snap.forEach(child => {
+                count++;
+                const data = child.val();
+                const div = document.createElement('div');
+                div.className = 'order-item';
+                div.style.marginBottom = '10px';
+                div.style.padding = '10px';
+                div.style.border = '1px solid #eee';
+                div.style.borderRadius = '8px';
+                div.innerHTML = `
+                    <h4 style="margin-top:0;margin-bottom:8px;">Package Code: ${data.packageCode || 'N/A'}</h4>
+                    <p style="font-size:0.9em;margin:3px 0;"><strong>Platform:</strong> ${data.platform || 'N/A'}</p>
+                    <button type="button" class="shipped-detail-btn" data-orderkey="${child.key}" style="width:auto;padding:8px 15px;margin-top:10px;font-size:0.9em;">ดูรายละเอียด</button>`;
+                listContainer.appendChild(div);
+            });
+        }
+        if (count === 0) {
+            noMsg.classList.remove('hidden');
+            showAppStatus('ไม่พบพัสดุที่ส่งแล้ว', 'info', appStatus);
+        } else {
+            showAppStatus(`พบ ${count} รายการที่ส่งแล้ว`, 'success', appStatus);
+        }
+
+        listContainer.querySelectorAll('.shipped-detail-btn').forEach(btn => {
+            btn.addEventListener('click', e => loadShippedOrderDetail(e.target.dataset.orderkey));
+        });
+    } catch (err) {
+        console.error('loadShippedOrders error', err);
+        listContainer.innerHTML = '<p style="color:red;text-align:center;">เกิดข้อผิดพลาด</p>';
+        showAppStatus('เกิดข้อผิดพลาดในการโหลดรายการ', 'error', appStatus);
+    }
+}
+
+async function loadShippedOrderDetail(orderKey) {
+    currentDetailOrderKey = orderKey;
+    const appStatus = document.getElementById('appStatus');
+    const infoDiv = document.getElementById('shippedOrderDetailInfo');
+    const packageSpan = document.getElementById('detailPackageCode');
+    const confirmBtn = document.getElementById('confirmShipmentButton');
+    if (!infoDiv || !packageSpan || !appStatus) return;
+
+    showAppStatus('กำลังโหลดรายละเอียด...', 'info', appStatus);
+    try {
+        const snap = await get(ref(database, 'orders/' + orderKey));
+        if (snap.exists()) {
+            const data = snap.val();
+            packageSpan.textContent = data.packageCode || orderKey;
+            infoDiv.innerHTML = `
+                <p><strong>Platform:</strong> ${data.platform || 'N/A'}</p>
+                <p><strong>ส่งจริงเมื่อ:</strong> ${data.shipmentInfo?.shippedAt_actual ? formatDateTimeDDMMYYYYHHMM(data.shipmentInfo.shippedAt_actual) : '-'}</p>
+                <p><strong>Batch ID:</strong> ${data.shipmentInfo?.batchId || '-'}</p>
+                <p><strong>ยืนยันโดยผู้ดูแล:</strong> ${data.shipmentInfo?.adminVerifiedBy ? '✓' : 'ยังไม่ได้ยืนยัน'}</p>
+            `;
+            const role = getCurrentUserRole();
+            if (role === 'administrator' || role === 'supervisor') {
+                confirmBtn.classList.remove('hidden');
+            } else {
+                confirmBtn.classList.add('hidden');
+            }
+            showPage('shippedOrderDetailPage');
+            showAppStatus('โหลดรายละเอียดแล้ว', 'success', appStatus);
+        } else {
+            showAppStatus('ไม่พบข้อมูลพัสดุ', 'error', appStatus);
+        }
+    } catch (err) {
+        console.error('loadShippedOrderDetail error', err);
+        showAppStatus('เกิดข้อผิดพลาดในการโหลดรายละเอียด', 'error', appStatus);
+    }
+}
+
+async function confirmShipmentAdmin() {
+    const user = getCurrentUser();
+    const appStatus = document.getElementById('appStatus');
+    if (!user || !currentDetailOrderKey || !appStatus) return;
+    const updates = {};
+    updates[`/orders/${currentDetailOrderKey}/shipmentInfo/adminVerifiedBy`] = user.uid;
+    updates[`/orders/${currentDetailOrderKey}/shipmentInfo/adminVerifiedAt`] = serverTimestamp();
+    try {
+        await update(ref(database), updates);
+        showAppStatus('ยืนยันแล้ว', 'success', appStatus);
+        loadShippedOrderDetail(currentDetailOrderKey);
+    } catch (err) {
+        console.error('confirmShipmentAdmin error', err);
+        showAppStatus('เกิดข้อผิดพลาดในการยืนยัน', 'error', appStatus);
+    }
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -140,6 +140,9 @@ export function showPage(pageId) {
         } else if (pageId === 'operatorShippingBatchPage') {
             if (typeof window.setupShippingBatchPageGlobal === 'function') window.setupShippingBatchPageGlobal();
             else { console.error("setupShippingBatchPageGlobal function not found on window.");}
+        } else if (pageId === 'shippedOrdersPage') {
+            if (typeof window.loadShippedOrdersGlobal === 'function') window.loadShippedOrdersGlobal();
+            else { console.error("loadShippedOrdersGlobal function not found on window."); }
         }
     } else {
         console.error(`UI: Page with ID "${pageId}" not found in HTML. Defaulting to dashboard.`);
@@ -172,6 +175,7 @@ export function setupRoleBasedUI(currentUserRoleForNav) {
         { pageId: 'operatorTaskListPage', icon: 'inventory_2', label: 'รายการรอแพ็ก', roles: ['administrator','operator','supervisor'] },
         { pageId: 'supervisorPackCheckListPage', icon: 'checklist', label: 'รอตรวจแพ็ก', roles: ['administrator','supervisor'] },
         { pageId: 'operatorShippingBatchPage', icon: 'local_shipping', label: 'เตรียมส่งของ', roles: ['administrator','operator','supervisor'] },
+        { pageId: 'shippedOrdersPage', icon: 'check_circle', label: 'ส่งแล้ว', roles: ['administrator','operator','supervisor'] },
     ];
 
     const allowedItems = navItems.filter(item => item.roles.includes(currentUserRoleForNav));


### PR DESCRIPTION
## Summary
- default to rear camera when scanning packages
- add Shipped Orders page with detail view and admin confirmation
- show Sent summary card clickable to shipped orders
- wire up new page in navigation and initialization

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6846609513f88324877b4c38b7a36725