### PR TITLE
Add scan stop and complete count

### DIFF
--- a/delivery.html
+++ b/delivery.html
@@ -57,6 +57,7 @@
                             <option value="Pending Supervisor Pack Check">รอตรวจแพ็ก</option>
                             <option value="Ready for Shipment">รอส่ง</option>
                             <option value="Shipped">ส่งแล้ว</option>
+                            <option value="Shipment Approved">เสร็จสิ้น</option>
                         </select>
                         <input id="logSearchPackageCode" type="text" placeholder="รหัสพัสดุ" style="flex:1; padding:8px; margin-bottom:0;">
                         <button id="applyLogFilterButton" type="button" class="secondary" style="width:auto; font-size:0.8em; padding:8px;">ค้นหา</button>

--- a/js/dashboardPage.js
+++ b/js/dashboardPage.js
@@ -129,6 +129,10 @@ function updateSummaryCards(orders) {
     const pendingCheck = orders.filter(o => o.status === 'Pending Supervisor Pack Check').length;
     const readyToShip = orders.filter(o => (o.status === 'Ready for Shipment' || o.status === 'Pack Approved')).length;
     const shipped = orders.filter(o => (o.status === 'Shipped' || o.status === 'Shipment Approved') && !o.shipmentInfo?.adminVerifiedBy).length;
+    const completed = orders.filter(o => (
+        o.status === 'Shipment Approved' ||
+        (o.status === 'Shipped' && o.shipmentInfo?.adminVerifiedBy)
+    )).length;
     const shippedAwaitingVerify = shipped;
 
     const todayStr = new Date().toISOString().slice(0, 10);
@@ -139,6 +143,7 @@ function updateSummaryCards(orders) {
     createSummaryCard('รอตรวจเช็ค', pendingCheck, total > 0 ? `${Math.round((pendingCheck/total)*100)}%` : '0%', 'fact_check', 'supervisorPackCheckListPage');
     createSummaryCard('เตรียมส่ง', readyToShip, total > 0 ? `${Math.round((readyToShip/total)*100)}%` : '0%', 'local_shipping', 'operatorShippingBatchPage');
     createSummaryCard('ส่งแล้ว', shipped, total > 0 ? `${Math.round((shipped/total)*100)}%` : '0%', 'check_circle', 'shippedOrdersPage');
+    createSummaryCard('เสร็จสิ้น', completed, total > 0 ? `${Math.round((completed/total)*100)}%` : '0%', 'done_all');
     if (typeof window.setNavBadgeCount === 'function') {
         window.setNavBadgeCount('operatorTaskListPage', readyToPack);
         window.setNavBadgeCount('supervisorPackCheckListPage', pendingCheck);
@@ -183,7 +188,7 @@ function updateDueTodayTable(orders) {
         r.insertCell().textContent = o.packageCode || 'N/A';
         r.insertCell().textContent = o.platformOrderId || '-';
         r.insertCell().textContent = o.platform || 'N/A';
-        r.insertCell().textContent = translateStatusToThai(o.status);
+        r.insertCell().textContent = translateStatusToThai(o.status, !!o.shipmentInfo?.adminVerifiedBy);
         r.insertCell().textContent = formatDateTimeDDMMYYYYHHMM(o.createdAt);
         r.insertCell().textContent = formatDateDDMMYYYY(o.dueDate);
         const actCell = r.insertCell();
@@ -224,7 +229,7 @@ function updateOrdersLogTable(orders, filterStatus = 'all', searchCode = '') {
         r.insertCell().textContent = o.packageCode || 'N/A';
         r.insertCell().textContent = o.platformOrderId || '-';
         r.insertCell().textContent = o.platform || 'N/A';
-        r.insertCell().textContent = translateStatusToThai(o.status);
+        r.insertCell().textContent = translateStatusToThai(o.status, !!o.shipmentInfo?.adminVerifiedBy);
         r.insertCell().textContent = formatDateTimeDDMMYYYYHHMM(o.createdAt);
         r.insertCell().textContent = formatDateDDMMYYYY(o.dueDate);
         const actCell = r.insertCell();
@@ -278,7 +283,8 @@ async function handleEditOrder(orderKey) {
         'Ready to Pack': 'รอแพ็ก',
         'Pending Supervisor Pack Check': 'รอตรวจแพ็ค',
         'Ready for Shipment': 'รอส่ง',
-        'Shipped': 'ส่งแล้ว'
+        'Shipped': 'ส่งแล้ว',
+        'Shipment Approved': 'เสร็จสิ้น'
     };
     Object.entries(statusOptions).forEach(([val, text]) => {
         const opt = document.createElement('option');

--- a/js/operatorTasksPage.js
+++ b/js/operatorTasksPage.js
@@ -245,7 +245,7 @@ async function onPackingScanSuccess(decodedText) {
 
     if (orderKeyFound) {
         beepSuccess();
-        stopScanForPacking();
+        await stopScanForPacking();
         if (typeof window.loadOrderForPacking === 'function') {
             window.loadOrderForPacking(orderKeyFound);
         }

--- a/js/utils.js
+++ b/js/utils.js
@@ -167,7 +167,10 @@ export function formatDateTimeDDMMYYYYHHMM(dateInput) {
  * @param {string} status - The status value stored in the database
  * @returns {string} - Thai label for the status
  */
-export function translateStatusToThai(status) {
+export function translateStatusToThai(status, adminVerified = false) {
+    if (status === 'Shipped' && adminVerified) {
+        return 'เสร็จสิ้น';
+    }
     const map = {
         'Adding Items': 'รอเพิ่มสินค้า',
         'Ready to Pack': 'รอแพ็ก',
@@ -177,7 +180,7 @@ export function translateStatusToThai(status) {
         'Ready for Shipment': 'รอส่ง',
         'Shipped - Pending Supervisor Check': 'ส่งแล้ว-รอตรวจ',
         'Shipped': 'ส่งแล้ว',
-        'Shipment Approved': 'ตรวจส่งแล้ว'
+        'Shipment Approved': 'เสร็จสิ้น'
     };
     return map[status] || status || 'N/A';
 }


### PR DESCRIPTION
## Summary
- treat previously confirmed shipments as `เสร็จสิ้น`
- show translated status as completed when shipment is verified
- stop QR scanner immediately after a successful pack scan

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684677d55514832488f658b433e8f681