### PR TITLE
Improve usability of dashboard and shipped orders

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -237,3 +237,32 @@ tbody tr:hover { background-color: #f1f8ff; }
 #dueTodayTableContainer thead tr { background-color: #ffe5e5; }
 .due-today-row { background-color: #fff0f0; }
 
+/* Completed order row highlight */
+.completed-row { background-color: #e6ffe6; }
+
+/* Summary cards container responsive styles */
+#summaryCardsContainer {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    gap: 15px;
+    margin-bottom: 20px;
+}
+#summaryCardsContainer::-webkit-scrollbar {
+    height: 8px;
+}
+#summaryCardsContainer::-webkit-scrollbar-thumb {
+    background-color: rgba(0,0,0,0.3);
+    border-radius: 4px;
+}
+@media (min-width: 768px) {
+    #summaryCardsContainer {
+        flex-wrap: wrap;
+        overflow-x: visible;
+        justify-content: center;
+    }
+}
+
+/* Batch photo toggle */
+.batch-photo { max-width:100%; margin:10px 0; border:1px solid #dce4ec; border-radius:8px; }
+

--- a/delivery.html
+++ b/delivery.html
@@ -30,7 +30,7 @@
                     <span id="currentDateDisplay" style="font-size:0.9em;"></span>
                     <button id="refreshDashboardButton" type="button" class="secondary" style="width:auto; font-size:0.8em; padding:8px;">รีเฟรช</button>
                 </div>
-                <div id="summaryCardsContainer" style="display: flex; flex-wrap: wrap; gap: 15px; margin-bottom: 20px;"></div>
+                <div id="summaryCardsContainer"></div>
                 <div id="chartsContainer" style="margin-bottom: 20px;">
                     <h3>สถิติรายวัน</h3>
                     <div style="height:250px;"><canvas id="dailyStatsChart"></canvas></div>

--- a/js/dashboardPage.js
+++ b/js/dashboardPage.js
@@ -226,6 +226,8 @@ function updateOrdersLogTable(orders, filterStatus = 'all', searchCode = '') {
         r.dataset.orderkey = o.key;
         r.dataset.duedate = o.dueDate || '';
         r.dataset.status = o.status || '';
+        const isCompleted = (o.status === 'Shipment Approved') || (o.status === 'Shipped' && o.shipmentInfo?.adminVerifiedBy);
+        if (isCompleted) r.classList.add('completed-row');
         r.insertCell().textContent = o.packageCode || 'N/A';
         r.insertCell().textContent = o.platformOrderId || '-';
         r.insertCell().textContent = o.platform || 'N/A';

--- a/js/shippedOrdersPage.js
+++ b/js/shippedOrdersPage.js
@@ -80,7 +80,11 @@ export async function loadShippedOrders() {
             if (role === 'administrator') {
                 html += `<p style="font-size:0.9em;margin:2px 0;"><strong>Batch ID:</strong> ${batch.batchId}</p>`;
             }
-            if (batch.groupPhotoUrl) html += `<img src="${batch.groupPhotoUrl}" alt="Batch Photo" style="max-width:100%; margin:10px 0;border:1px solid #dce4ec;border-radius:8px;" />`;
+            if (batch.groupPhotoUrl) {
+                const photoId = `batch_photo_${batch.batchId}`;
+                html += `<button type="button" class="toggle-batch-photo-btn" data-target="${photoId}" style="width:auto;margin:5px 0;">ดูรูปการส่ง</button>`;
+                html += `<img id="${photoId}" src="${batch.groupPhotoUrl}" class="batch-photo hidden" alt="Batch Photo" />`;
+            }
             html += '<ul style="list-style-type:none;padding-left:0;">';
             batch.orders.forEach(o => {
                 if (!o.data.shipmentInfo?.adminVerifiedBy) pendingCount++;
@@ -92,6 +96,13 @@ export async function loadShippedOrders() {
             html += '</ul>';
             div.innerHTML = html;
             listContainer.appendChild(div);
+            const toggleBtn = div.querySelector('.toggle-batch-photo-btn');
+            if (toggleBtn) {
+                toggleBtn.addEventListener('click', () => {
+                    const img = div.querySelector(`#${toggleBtn.dataset.target}`);
+                    if (img) img.classList.toggle('hidden');
+                });
+            }
         });
 
         if (totalCount === 0) {


### PR DESCRIPTION
## Summary
- highlight completed orders in history table
- let summary cards scroll horizontally on mobile
- tweak shipped orders page so batch photos show on demand
- style updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846852fae0c8324bdf6975886f1e561