### PR TITLE
Reduce uploaded image size

### DIFF
--- a/js/operatorPackingPage.js
+++ b/js/operatorPackingPage.js
@@ -211,7 +211,7 @@ async function confirmPacking() {
             const fname = `${currentOrderKeyForPacking}_${ts}_${Math.random().toString(36).substring(2,6)}.${ext}`;
             const storagePath = `packingPhotos/${currentOrderKeyForPacking}/${fname}`;
             const imageRef = storageRefFirebase(storage, storagePath);
-            const resized = await resizeImageFileIfNeeded(file, 1500);
+            const resized = await resizeImageFileIfNeeded(file, 1000);
             await uploadBytes(imageRef, resized);
             photoUrls.push(await getDownloadURL(imageRef));
         }

--- a/js/operatorShippingPage.js
+++ b/js/operatorShippingPage.js
@@ -392,7 +392,7 @@ async function finalizeShipment() {
         const photoFileName = `shipment_${currentActiveBatchId}_${timestamp}.${extension}`;
         const photoPath = `shipmentGroupPhotos/${currentActiveBatchId}/${photoFileName}`;
         const imageRef = storageRefFirebase(storage, photoPath); // Use aliased storageRef
-        const resized = await resizeImageFileIfNeeded(shipmentGroupPhotoFile, 1500);
+        const resized = await resizeImageFileIfNeeded(shipmentGroupPhotoFile, 1000);
         await uploadBytes(imageRef, resized);
         const groupPhotoUrl = await getDownloadURL(imageRef);
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -209,10 +209,10 @@ export function getTimestampForFilename(date = new Date()) {
  * Returns the original file if no resizing is needed or resizing fails.
  *
  * @param {File} file - Image file to resize.
- * @param {number} [maxDim=1500] - Maximum width or height in pixels.
+ * @param {number} [maxDim=1000] - Maximum width or height in pixels.
  * @returns {Promise<File>} - Promise resolving to the resized File object.
  */
-export function resizeImageFileIfNeeded(file, maxDim = 1500) {
+export function resizeImageFileIfNeeded(file, maxDim = 1000) {
     return new Promise(resolve => {
         const img = new Image();
         img.onload = () => {


### PR DESCRIPTION
## Summary
- resize uploaded images to max 1000px

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846b2a19af483249f0ebcfbb3df5d45