### PR TITLE
Add realtime dashboard updates

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -8,7 +8,7 @@ import { initializeCoreDOMElements, showPage, setupRoleBasedUI } from './ui.js';
 import { initializeAdminOrderPageListeners } from './adminOrderPage.js';
 import { initializeAdminItemsPageListeners, loadOrderForAddingItems } from './adminItemsPage.js';
 import { initializeOperatorPackingPageListeners, loadOrderForPacking as operatorLoadOrderForPacking } from './operatorPackingPage.js';
-import { initializeDashboardPageListeners, updateCurrentDateOnDashboard, loadDashboardData } from './dashboardPage.js';
+import { initializeDashboardPageListeners, updateCurrentDateOnDashboard, loadDashboardData, startDashboardRealtime, stopDashboardRealtime } from './dashboardPage.js';
 import { initializeSupervisorPackCheckListeners, loadOrdersForPackCheck } from './supervisorPackCheckPage.js';
 import { initializeOperatorTasksPageListeners, loadOperatorPendingTasks } from './operatorTasksPage.js';
 import { initializeOperatorShippingPageListeners, setupShippingBatchPage } from './operatorShippingPage.js';
@@ -42,6 +42,7 @@ function setCurrentUserAndUpdateUI(user, role, displayName) {
                 bottomNavContainerEl.classList.remove('hidden');
                 setupRoleBasedUI(role);
             }
+            startDashboardRealtime();
             showPage('dashboardPage');
         } else {
             userDisplayEmailEl.textContent = '';
@@ -52,6 +53,7 @@ function setCurrentUserAndUpdateUI(user, role, displayName) {
                 bottomNavContainerEl.classList.add('hidden');
                 bottomNavContainerEl.innerHTML = '';
             }
+            stopDashboardRealtime();
             if (loginPageEl) {
                 loginPageEl.classList.remove('hidden');
             } else {


### PR DESCRIPTION
## Summary
- add real-time listener for dashboard data via Firebase onValue
- start and stop dashboard updates with authentication state

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684800af0b08832480851fd44bdd4319