### PR TITLE
Fix QR scanner not stopping

### DIFF
--- a/js/operatorShippingPage.js
+++ b/js/operatorShippingPage.js
@@ -209,7 +209,7 @@ async function stopScanForBatch() {
     if (html5QrScannerForBatch) {
         try {
             // Some devices may trigger stop twice; check if scanner is running
-            if (html5QrScannerForBatch._isScanning) {
+            if (html5QrScannerForBatch.isScanning) {
                 await html5QrScannerForBatch.stop();
             }
             await html5QrScannerForBatch.clear();

--- a/js/operatorTasksPage.js
+++ b/js/operatorTasksPage.js
@@ -211,7 +211,7 @@ async function stopScanForPacking() {
     isPackingScannerStopping = true;
     if (html5QrScannerForPacking) {
         try {
-            if (html5QrScannerForPacking._isScanning) {
+            if (html5QrScannerForPacking.isScanning) {
                 await html5QrScannerForPacking.stop();
             }
             await html5QrScannerForPacking.clear();


### PR DESCRIPTION
## Summary
- ensure scanning is stopped by checking `isScanning` property

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848e47f90588324bd03837da13cf811