### PR TITLE
Update UI and photo naming

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -101,7 +101,7 @@ label { display: block; margin-bottom: 8px; font-weight: 600; color: #555; font-
 .remove-photo-btn { position:absolute; top:2px; right:2px; background:rgba(0,0,0,0.6); color:#fff; border:none; border-radius:50%; width:20px; height:20px; line-height:18px; cursor:pointer; font-size:14px; }
 #shipmentGroupPhotoPreview { max-width:100%; max-height:250px; margin-top:10px; border:1px solid #dce4ec; display:block; border-radius: 8px; }
 
-.summary-card { background-color:#fff; border-radius:12px; padding:20px; box-shadow: 0 2px 8px rgba(0,0,0,0.07); flex: 1; min-width: 160px; text-align:left; border-left: 5px solid var(--primary-blue); }
+.summary-card { background-color:#fff; border-radius:12px; padding:20px; box-shadow: 0 2px 8px rgba(0,0,0,0.07); width:100%; min-width:160px; text-align:left; border-left:5px solid var(--primary-blue); box-sizing:border-box; }
 .summary-card.clickable { cursor:pointer; }
 .summary-card-icon {
     font-size: 5em;
@@ -242,24 +242,14 @@ tbody tr:hover { background-color: #f1f8ff; }
 
 /* Summary cards container responsive styles */
 #summaryCardsContainer {
-    display: flex;
-    flex-wrap: nowrap;
-    overflow-x: auto;
+    display: grid;
+    grid-template-columns: 1fr;
     gap: 15px;
     margin-bottom: 20px;
 }
-#summaryCardsContainer::-webkit-scrollbar {
-    height: 8px;
-}
-#summaryCardsContainer::-webkit-scrollbar-thumb {
-    background-color: rgba(0,0,0,0.3);
-    border-radius: 4px;
-}
-@media (min-width: 768px) {
+@media (min-width: 480px) {
     #summaryCardsContainer {
-        flex-wrap: wrap;
-        overflow-x: visible;
-        justify-content: center;
+        grid-template-columns: repeat(2, 1fr);
     }
 }
 

--- a/js/operatorPackingPage.js
+++ b/js/operatorPackingPage.js
@@ -7,6 +7,7 @@ import { showAppStatus, showToast, formatDateDDMMYYYY, getTimestampForFilename, 
 import { getCurrentUser, getCurrentUserRole } from './auth.js';
 
 let currentOrderKeyForPacking = null;
+let currentOrderPackageCode = null;
 let packingPhotoFiles = [];
 let existingPackingPhotoUrls = [];
 
@@ -56,6 +57,7 @@ export async function loadOrderForPacking(orderKey) {
         return;
     }
     currentOrderKeyForPacking = orderKey;
+    currentOrderPackageCode = null;
     packingPhotoFiles = [];
 
     showAppStatus('กำลังโหลดข้อมูลพัสดุ...', 'info', opPacking_appStatus);
@@ -72,7 +74,8 @@ export async function loadOrderForPacking(orderKey) {
                 return;
             }
 
-            if(opPacking_currentOrderIdSpan) opPacking_currentOrderIdSpan.textContent = orderData.packageCode || orderKey;
+            currentOrderPackageCode = orderData.packageCode || orderKey;
+            if(opPacking_currentOrderIdSpan) opPacking_currentOrderIdSpan.textContent = currentOrderPackageCode;
             if(opPacking_platformSpan) opPacking_platformSpan.textContent = orderData.platform || 'N/A';
             if(opPacking_dueDateSpan) opPacking_dueDateSpan.textContent = formatDateDDMMYYYY(orderData.dueDate);
             
@@ -210,7 +213,8 @@ async function confirmPacking() {
         for (const file of packingPhotoFiles) {
             const ts = getTimestampForFilename();
             const ext = file.name.split('.').pop();
-            const fname = `${currentOrderKeyForPacking}_${ts}_${Math.random().toString(36).substring(2,6)}.${ext}`;
+            const code = currentOrderPackageCode || currentOrderKeyForPacking;
+            const fname = `${code}_${ts}.${ext}`;
             const storagePath = `packingPhotos/${currentOrderKeyForPacking}/${fname}`;
             const imageRef = storageRefFirebase(storage, storagePath);
             const resized = await resizeImageFileIfNeeded(file, 1000);

--- a/js/operatorShippingPage.js
+++ b/js/operatorShippingPage.js
@@ -1,7 +1,7 @@
 // js/operatorShippingPage.js
 import { showPage, uiElements } from './ui.js';
 import { database, storage, auth } from './config.js';
-import { ref, set, get, update, serverTimestamp, push, query, orderByChild, equalTo } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-database.js";
+import { ref, set, get, update, serverTimestamp, query, orderByChild, equalTo } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-database.js";
 import { ref as storageRefFirebase, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-storage.js"; // Renamed to avoid conflict
 import { showAppStatus, showToast, beepSuccess, beepError, getTimestampForFilename, resizeImageFileIfNeeded } from './utils.js';
 import { getCurrentUser, getCurrentUserRole } from './auth.js';
@@ -111,11 +111,10 @@ async function createOrSelectBatch() {
     }
     currentBatchCourier = courier;
 
-    // For simplicity, we'll always create a new batch ID.
-    // In a real app, you might want to let users resume an existing open batch.
-    const newBatchRef = push(ref(database, 'shipmentBatches'));
-    currentActiveBatchId = newBatchRef.key;
+    // Create batch ID based on timestamp to make it human readable
+    currentActiveBatchId = getTimestampForFilename();
     itemsInCurrentBatch = {}; // Reset items for the new batch
+    const newBatchRef = ref(database, `shipmentBatches/${currentActiveBatchId}`);
 
     const batchData = {
         batchId: currentActiveBatchId,
@@ -426,8 +425,7 @@ async function finalizeShipment() {
 
     try {
         if (!currentActiveBatchId) {
-            const newBatchRef = push(ref(database, 'shipmentBatches'));
-            currentActiveBatchId = newBatchRef.key;
+            currentActiveBatchId = getTimestampForFilename();
         }
 
         // 1. Upload group photo


### PR DESCRIPTION
## Summary
- switch summary cards to a two column responsive grid
- include package code in packing photo filenames
- generate shipment batch IDs from timestamps
- adjust shipment group photo naming

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684a63e2f8a08324b3affa3dd39ff295