### PR TITLE
Add parcel detail page and graph enhancements

### DIFF
--- a/delivery.html
+++ b/delivery.html
@@ -135,6 +135,15 @@
                 <p id="noParcelsMessage" class="hidden" style="text-align:center; padding:20px;">ไม่พบข้อมูล</p>
             </div>
 
+            <!-- Parcel Detail Page -->
+            <div id="parcelDetailPage" class="container page hidden">
+                <h2>รายละเอียดพัสดุ (Package Code: <span id="parcelDetailCode"></span>)</h2>
+                <div id="parcelDetailInfo"></div>
+                <div id="parcelDetailPhotos" style="margin-top:10px;"></div>
+                <button id="parcelDetailAddItemsButton" type="button" class="secondary" style="width:auto; margin-top:10px; margin-right:10px;">เพิ่มรายการสินค้า</button>
+                <button id="backToParcelListButton" type="button" class="secondary" style="width:auto; margin-top:10px;">กลับ</button>
+            </div>
+
             <!-- Admin: Create Order Page -->
             <div id="adminCreateOrderPage" class="container page hidden">
                 <h2>สร้างออเดอร์ใหม่</h2>

--- a/js/adminParcelDetailPage.js
+++ b/js/adminParcelDetailPage.js
@@ -1,0 +1,87 @@
+import { database } from './config.js';
+import { ref, get } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-database.js";
+import { showPage } from './ui.js';
+import { formatDateTimeDDMMYYYYHHMM, formatDateDDMMYYYY, translateStatusToThai } from './utils.js';
+import { getCurrentUserRole } from './auth.js';
+
+let currentDetailKey = null;
+
+export function initializeAdminParcelDetailPageListeners() {
+    const backBtn = document.getElementById('backToParcelListButton');
+    if (backBtn) backBtn.addEventListener('click', () => showPage('parcelListPage'));
+
+    const addItemsBtn = document.getElementById('parcelDetailAddItemsButton');
+    if (addItemsBtn) {
+        addItemsBtn.addEventListener('click', () => {
+            if (currentDetailKey && typeof window.loadOrderForAddingItems === 'function') {
+                window.loadOrderForAddingItems(currentDetailKey);
+            }
+        });
+    }
+}
+
+export async function loadParcelDetail(orderKey) {
+    currentDetailKey = orderKey;
+    const appStatus = document.getElementById('appStatus');
+    const infoDiv = document.getElementById('parcelDetailInfo');
+    const codeSpan = document.getElementById('parcelDetailCode');
+    const photoDiv = document.getElementById('parcelDetailPhotos');
+    if (!infoDiv || !codeSpan) return;
+    if (appStatus) appStatus.textContent = 'กำลังโหลดรายละเอียด...';
+    try {
+        const snap = await get(ref(database, 'orders/' + orderKey));
+        if (snap.exists()) {
+            const data = snap.val();
+            codeSpan.textContent = data.packageCode || orderKey;
+            let html = `
+                <p><strong>Platform:</strong> ${data.platform || 'N/A'}</p>
+                <p><strong>Platform Order ID:</strong> ${data.platformOrderId || '-'}</p>
+                <p><strong>สถานะ:</strong> ${translateStatusToThai(data.status, !!data.shipmentInfo?.adminVerifiedBy)}</p>
+                <p><strong>Created:</strong> ${formatDateTimeDDMMYYYYHHMM(data.createdAt)}</p>
+                <p><strong>Due Date:</strong> ${formatDateDDMMYYYY(data.dueDate)}</p>
+            `;
+            if (data.items) {
+                html += '<h3>รายการสินค้า:</h3><ul>';
+                Object.values(data.items).forEach(it => {
+                    html += `<li>${it.productName} - ${it.quantity} ${it.unit}</li>`;
+                });
+                html += '</ul>';
+            }
+            infoDiv.innerHTML = html;
+            if (photoDiv) {
+                photoDiv.innerHTML = '';
+                const urls = data.packingInfo?.packingPhotoUrls ? [...data.packingInfo.packingPhotoUrls] : [];
+                if (urls.length) {
+                    urls.forEach((url, idx) => {
+                        const img = document.createElement('img');
+                        img.src = url;
+                        img.className = 'lightbox-thumb';
+                        img.style.maxWidth = '100px';
+                        img.style.marginRight = '5px';
+                        img.style.marginBottom = '5px';
+                        img.addEventListener('click', () => {
+                            if (typeof window.showImageAlbum === 'function') window.showImageAlbum(urls, idx);
+                        });
+                        photoDiv.appendChild(img);
+                    });
+                }
+            }
+            const addItemsBtn = document.getElementById('parcelDetailAddItemsButton');
+            const role = getCurrentUserRole();
+            if (addItemsBtn) {
+                if (['administrator','supervisor'].includes(role)) {
+                    addItemsBtn.classList.remove('hidden');
+                } else {
+                    addItemsBtn.classList.add('hidden');
+                }
+            }
+            showPage('parcelDetailPage');
+            if (appStatus) appStatus.textContent = 'โหลดรายละเอียดแล้ว';
+        } else {
+            if (appStatus) appStatus.textContent = 'ไม่พบข้อมูลพัสดุ';
+        }
+    } catch (err) {
+        console.error('loadParcelDetail error', err);
+        if (appStatus) appStatus.textContent = 'เกิดข้อผิดพลาดในการโหลดรายละเอียด';
+    }
+}

--- a/js/adminParcelListPage.js
+++ b/js/adminParcelListPage.js
@@ -146,7 +146,7 @@ export async function loadParcelList(timeFilter = 'today', startDate = null, end
 
             tr.classList.add('clickable-row');
             tr.addEventListener('click', () => {
-                if (typeof window.loadOrderForAddingItems === 'function') window.loadOrderForAddingItems(o.key);
+                if (typeof window.loadParcelDetail === 'function') window.loadParcelDetail(o.key);
             });
         });
     } catch (err) {

--- a/js/dashboardPage.js
+++ b/js/dashboardPage.js
@@ -519,8 +519,8 @@ function renderCharts(orders, timeFilter = 'today', startDateStr = null, endDate
         data: {
             labels: dailyLabels,
             datasets: [
-                { label: 'สร้างใหม่', data: dailyCreatedCounts, backgroundColor: 'rgba(54, 162, 235, 0.7)' },
-                { label: 'ส่งแล้ว', data: dailyShippedCounts, type: 'line', borderColor: 'rgba(75, 192, 192, 1)', backgroundColor: 'rgba(75,192,192,0.3)', fill: false }
+                { label: 'สร้างใหม่', data: dailyCreatedCounts, backgroundColor: 'rgba(54, 162, 235, 0.7)', order: 1 },
+                { label: 'ส่งแล้ว', data: dailyShippedCounts, type: 'line', borderColor: 'rgba(75, 192, 192, 1)', backgroundColor: 'rgba(75,192,192,0.3)', fill: false, pointBackgroundColor: '#e74c3c', pointBorderColor: '#e74c3c', pointRadius: 5, order: 2 }
             ]
         },
         options: {

--- a/js/main.js
+++ b/js/main.js
@@ -14,6 +14,7 @@ import { initializeOperatorTasksPageListeners, loadOperatorPendingTasks } from '
 import { initializeOperatorShippingPageListeners, setupShippingBatchPage, updateBatchIdVisibilityForRole } from './operatorShippingPage.js';
 import { initializeShippedOrdersPageListeners, loadShippedOrders } from './shippedOrdersPage.js';
 import { initializeAdminParcelListPageListeners, loadParcelList } from './adminParcelListPage.js';
+import { initializeAdminParcelDetailPageListeners, loadParcelDetail } from './adminParcelDetailPage.js';
 import { initializeImageLightbox, showImageAlbum } from './utils.js';
 
 window.currentUserFromAuth = null; 
@@ -87,6 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initializeOperatorShippingPageListeners();
     initializeShippedOrdersPageListeners();
     initializeAdminParcelListPageListeners();
+    initializeAdminParcelDetailPageListeners();
     initializeImageLightbox();
     
     console.log("Initial event listeners set up (main.js)");
@@ -101,6 +103,7 @@ document.addEventListener('DOMContentLoaded', () => {
     window.loadShippedOrdersGlobal = loadShippedOrders;
     window.updateBatchIdVisibilityForRoleGlobal = updateBatchIdVisibilityForRole;
     window.loadParcelListGlobal = loadParcelList;
+    window.loadParcelDetail = loadParcelDetail;
     window.loadOrderForPacking = operatorLoadOrderForPacking;
     window.loadOrderForAddingItems = loadOrderForAddingItems;
     window.showImageAlbum = showImageAlbum;


### PR DESCRIPTION
## Summary
- highlight shipment points on dashboard chart
- add new parcel detail page for viewing package information
- update parcel list to open the detail page instead of items page
- wire up new page through main initialization

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b03109d2c8324b6c352c2abba9144