### PR TITLE
Enable lightbox album on preview lists

### DIFF
--- a/js/supervisorPackCheckPage.js
+++ b/js/supervisorPackCheckPage.js
@@ -148,11 +148,17 @@ async function loadIndividualOrderForSupervisorCheck(orderKey) {
             }
 
             uiElements.checkOrderPackingPhotoContainer.innerHTML = '';
-            const urls = orderData.packingInfo?.packingPhotoUrls || (orderData.packingInfo?.packingPhotoUrl ? [orderData.packingInfo.packingPhotoUrl] : []);
-            urls.forEach(url => {
+            const urls = orderData.packingInfo?.packingPhotoUrls ||
+                (orderData.packingInfo?.packingPhotoUrl ? [orderData.packingInfo.packingPhotoUrl] : []);
+            urls.forEach((url, idx) => {
                 const img = document.createElement('img');
                 img.src = url;
                 img.classList.add('lightbox-thumb');
+                img.addEventListener('click', () => {
+                    if (typeof window.showImageAlbum === 'function') {
+                        window.showImageAlbum(urls, idx);
+                    }
+                });
                 uiElements.checkOrderPackingPhotoContainer.appendChild(img);
             });
             uiElements.checkOrderOperatorNotesDisplay.textContent = orderData.packingInfo?.operatorNotes || 'ไม่มีหมายเหตุจาก Operator';


### PR DESCRIPTION
## Summary
- add album click listener in `supervisorPackCheckPage.js`
- store preview URLs for packing photos and wire up album view in `operatorPackingPage.js`

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_684c23f009cc832484eee5a56d10e79e