### PR TITLE
Fix lightbox nav width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -271,6 +271,8 @@ tbody tr:hover { background-color: #f1f8ff; }
     padding:4px 10px;
     cursor:pointer;
     z-index:10100;
+    width:auto;
+    margin:0;
 }
 #lightboxPrev { left:20px; }
 #lightboxNext { right:20px; }


### PR DESCRIPTION
## Summary
- tweak `.lightbox-nav` style to override global button width

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c63a3e1188324bcc4e0e975e6cba1