### PR TITLE
Add desktop drag navigation for lightbox

### DIFF
--- a/js/home.js
+++ b/js/home.js
@@ -1,5 +1,6 @@
 // js/home.js - handles login for the home page
 import { initializeAuthEventListeners, onAuthStateChangeHandler } from './auth.js';
+import { initializeImageLightbox } from './utils.js';
 
 function setCurrentUserAndUpdateUI(user, role, displayName) {
     const loginPage = document.getElementById('loginPage');
@@ -31,4 +32,5 @@ function setCurrentUserAndUpdateUI(user, role, displayName) {
 document.addEventListener('DOMContentLoaded', () => {
     initializeAuthEventListeners();
     onAuthStateChangeHandler(setCurrentUserAndUpdateUI);
+    initializeImageLightbox();
 });

--- a/js/utils.js
+++ b/js/utils.js
@@ -307,6 +307,29 @@ export function initializeImageLightbox() {
         touchStartX = 0;
     });
 
+    let mouseStartX = 0;
+    let isDragging = false;
+    overlay.addEventListener('mousedown', e => {
+        isDragging = true;
+        mouseStartX = e.clientX;
+    });
+    overlay.addEventListener('mousemove', e => {
+        if (!isDragging) return;
+    });
+    overlay.addEventListener('mouseup', e => {
+        if (!isDragging) return;
+        const diff = e.clientX - mouseStartX;
+        if (Math.abs(diff) > 30) {
+            if (diff < 0) showNext();
+            else showPrev();
+        }
+        isDragging = false;
+        mouseStartX = 0;
+    });
+    overlay.addEventListener('mouseleave', () => {
+        isDragging = false;
+    });
+
     document.addEventListener('keydown', e => {
         if (overlay.classList.contains('hidden')) return;
         if (e.key === 'ArrowLeft') { showPrev(); }


### PR DESCRIPTION
## Summary
- enable image lightbox on the homepage
- extend `initializeImageLightbox` with mouse drag navigation

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684cd0698d148324beb164170d2a5b82