### PR TITLE
Shrink uploaded images

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Dragon Delivery App is a web-based logistics management tool built with Firebase
 - Order creation and QR code scanning using html5-qrcode
 - Dashboard with statistics rendered via Chart.js
 - Tracking and packing pages for daily operations
+- Uploaded photos are automatically resized so the longest side is 500&nbsp;px to speed up uploads
 
 ## Getting Started
 

--- a/js/operatorPackingPage.js
+++ b/js/operatorPackingPage.js
@@ -243,7 +243,7 @@ async function confirmPacking() {
             const fname = `${code}_${ts}.${ext}`;
             const storagePath = `packingPhotos/${currentOrderKeyForPacking}/${fname}`;
             const imageRef = storageRefFirebase(storage, storagePath);
-            const resized = await resizeImageFileIfNeeded(file, 1000);
+            const resized = await resizeImageFileIfNeeded(file, 500);
             await uploadBytes(imageRef, resized);
             photoUrls.push(await getDownloadURL(imageRef));
         }

--- a/js/operatorShippingPage.js
+++ b/js/operatorShippingPage.js
@@ -434,7 +434,7 @@ async function finalizeShipment() {
         const photoFileName = `shipment_${currentActiveBatchId}_${timestamp}.${extension}`;
         const photoPath = `shipmentGroupPhotos/${currentActiveBatchId}/${photoFileName}`;
         const imageRef = storageRefFirebase(storage, photoPath); // Use aliased storageRef
-        const resized = await resizeImageFileIfNeeded(shipmentGroupPhotoFile, 1000);
+        const resized = await resizeImageFileIfNeeded(shipmentGroupPhotoFile, 500);
         await uploadBytes(imageRef, resized);
         const groupPhotoUrl = await getDownloadURL(imageRef);
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -209,10 +209,10 @@ export function getTimestampForFilename(date = new Date()) {
  * Returns the original file if no resizing is needed or resizing fails.
  *
  * @param {File} file - Image file to resize.
- * @param {number} [maxDim=1000] - Maximum width or height in pixels.
+ * @param {number} [maxDim=500] - Maximum width or height in pixels.
  * @returns {Promise<File>} - Promise resolving to the resized File object.
  */
-export function resizeImageFileIfNeeded(file, maxDim = 1000) {
+export function resizeImageFileIfNeeded(file, maxDim = 500) {
     return new Promise(resolve => {
         const img = new Image();
         img.onload = () => {


### PR DESCRIPTION
## Summary
- resize uploaded images to 500px max
- update README about resizing

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d1364c2548324b2e7eadb197c6399