### PR TITLE
Add touch/mouse slide transition for lightbox

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -260,7 +260,13 @@ tbody tr:hover { background-color: #f1f8ff; }
 /* Lightbox styles */
 .lightbox-thumb { cursor:pointer; }
 .lightbox-overlay { position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.8); display:flex; justify-content:center; align-items:center; z-index:10000; }
-.lightbox-overlay img { max-width:95%; max-height:95%; border-radius:8px; box-shadow:0 0 10px rgba(0,0,0,0.5); }
+.lightbox-overlay img {
+    max-width:95%;
+    max-height:95%;
+    border-radius:8px;
+    box-shadow:0 0 10px rgba(0,0,0,0.5);
+    transition: transform 0.3s ease;
+}
 .lightbox-nav {
     position:absolute;
     top:50%;


### PR DESCRIPTION
## Summary
- allow dragging and swiping photos with a slide animation
- add transform transition on lightbox images

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d496c0e3c83249007f7f9a8524abc