### PR TITLE
Update header styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -207,13 +207,21 @@ tbody tr:hover { background-color: #f1f8ff; }
 }
 
 .logo {
-    display: block;
-    margin: 10px auto;
-    max-width: 160px;
+    width: 48px;
+    margin-right: 10px;
 }
 
 .app-header {
-    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 10px 0;
+}
+
+.app-title {
+    font-size: 1.5em;
+    font-weight: 700;
+    color: #fff;
 }
 
 /* Toast notifications */

--- a/delivery.html
+++ b/delivery.html
@@ -17,6 +17,7 @@
 <body>
     <header class="app-header">
         <img src="logo.svg" alt="Dragon Delivery Logo" class="logo">
+        <span class="app-title">Dragon Delivery</span>
     </header>
     <div id="appContainer">
         <!-- Main App Area (Content will be dynamically shown) -->

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 <body>
     <header class="app-header">
         <img src="logo.svg" alt="Dragon Delivery Logo" class="logo">
+        <span class="app-title">Dragon Delivery</span>
     </header>
     <!-- Login Page -->
     <div id="loginPage" class="container page">


### PR DESCRIPTION
## Summary
- use flexbox for app header and tweak logo
- show Dragon Delivery title in page headers

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684d5be86a208324a2dd604503e8ace8