### PR TITLE
Adjust summary card logic and logo display

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -207,8 +207,9 @@ tbody tr:hover { background-color: #f1f8ff; }
 }
 
 .logo {
-    width: 48px;
-    margin-right: 10px;
+    width: 150px;
+    height: auto;
+    margin-right: 0;
 }
 
 .app-header {

--- a/delivery.html
+++ b/delivery.html
@@ -17,7 +17,6 @@
 <body>
     <header class="app-header">
         <img src="logo.svg" alt="Dragon Delivery Logo" class="logo">
-        <span class="app-title">Dragon Delivery</span>
     </header>
     <div id="appContainer">
         <!-- Main App Area (Content will be dynamically shown) -->

--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
 <body>
     <header class="app-header">
         <img src="logo.svg" alt="Dragon Delivery Logo" class="logo">
-        <span class="app-title">Dragon Delivery</span>
     </header>
     <!-- Login Page -->
     <div id="loginPage" class="container page">

--- a/js/dashboardPage.js
+++ b/js/dashboardPage.js
@@ -222,10 +222,10 @@ function applyTimeFilter(orders, filterVal, startDateStr, endDateStr) {
 function updateSummaryCards(allOrders, timeFilter = 'today', startDateStr = null, endDateStr = null) {
     if (!el_summaryCardsContainer) return;
     el_summaryCardsContainer.innerHTML = '';
-    const filtered = applyTimeFilter(allOrders, timeFilter, startDateStr, endDateStr);
-    const readyToPack = filtered.filter(o => o.status === 'Ready to Pack').length;
-    const pendingCheck = filtered.filter(o => o.status === 'Pending Supervisor Pack Check').length;
-    const readyToShip = filtered.filter(o => (o.status === 'Ready for Shipment' || o.status === 'Pack Approved')).length;
+    // For pending/packing related cards always show totals from all time
+    const readyToPack = allOrders.filter(o => o.status === 'Ready to Pack').length;
+    const pendingCheck = allOrders.filter(o => o.status === 'Pending Supervisor Pack Check').length;
+    const readyToShip = allOrders.filter(o => (o.status === 'Ready for Shipment' || o.status === 'Pack Approved')).length;
 
     let shippedOrders = allOrders.filter(o => (o.status === 'Shipped' || o.status === 'Shipment Approved') && o.shipmentInfo?.shippedAt_actual);
     if (timeFilter !== 'all') {


### PR DESCRIPTION
## Summary
- show counts for pending tasks regardless of date filter
- make header logo wider for horizontal design
- drop text beside logo in `index.html` and `delivery.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684daeeea9108324ad744c4c523d3a72