### PR TITLE
Add platform detection rules for Shopee express and self-delivery

### DIFF
--- a/delivery.html
+++ b/delivery.html
@@ -111,8 +111,10 @@
                     <select id="parcelPlatformFilter" style="width:auto; padding:8px; margin-bottom:0;">
                         <option value="all">ทั้งหมด</option>
                         <option value="Shopee">Shopee</option>
+                        <option value="ส่งด่วน Shopee">ส่งด่วน Shopee</option>
                         <option value="Lazada">Lazada</option>
                         <option value="Tiktok">Tiktok</option>
+                        <option value="บริษัทส่งเอง">บริษัทส่งเอง</option>
                         <option value="Other">Other</option>
                     </select>
                 </div>

--- a/js/utils.js
+++ b/js/utils.js
@@ -9,6 +9,16 @@ export function detectPlatformFromPackageCode(packageCode) {
     if (!packageCode) return "Other";
     const code = packageCode.toUpperCase().replace(/\s+/g, ""); // Normalize for easier comparison
 
+    // If code starts with INV followed by numbers -> company's own delivery
+    if (/^INV\d+$/i.test(code)) {
+        return "บริษัทส่งเอง";
+    }
+
+    // If the code is exactly 4 alphanumeric characters -> Shopee express rush
+    if (/^[A-Z0-9]{4}$/i.test(code)) {
+        return "ส่งด่วน Shopee";
+    }
+
     // Shopee codes usually start with TH + digits or the prefix SPX
     if ((code.startsWith("TH") && code.length >= 12) || code.startsWith("SPX")) {
         return "Shopee";


### PR DESCRIPTION
## Summary
- detect Shopee express and self-delivery package codes in `utils.js`
- allow filtering these new platforms from the admin parcel list

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ef0ced5608324bb5331650e3686a3