### PR TITLE
Add alt text for generated images

### DIFF
--- a/js/adminParcelDetailPage.js
+++ b/js/adminParcelDetailPage.js
@@ -55,6 +55,7 @@ export async function loadParcelDetail(orderKey) {
                     urls.forEach((url, idx) => {
                         const img = document.createElement('img');
                         img.src = url;
+                        img.alt = `รูปการแพ็ค ${idx + 1}`;
                         img.className = 'lightbox-thumb';
                         img.style.maxWidth = '100px';
                         img.style.marginRight = '5px';

--- a/js/operatorPackingPage.js
+++ b/js/operatorPackingPage.js
@@ -166,6 +166,7 @@ function displayPackingPhotoPreviews() {
 
         const img = document.createElement('img');
         img.src = url;
+        img.alt = `รูปการแพ็ค ${idx + 1}`;
         img.classList.add('lightbox-thumb');
         img.addEventListener('click', () => {
             if (typeof window.showImageAlbum === 'function') {
@@ -193,6 +194,7 @@ function displayPackingPhotoPreviews() {
 
         const img = document.createElement('img');
         img.src = file.previewUrl;
+        img.alt = `รูปการแพ็ค ${existingPackingPhotoUrls.length + idx + 1}`;
         img.classList.add('lightbox-thumb');
         img.addEventListener('click', () => {
             if (typeof window.showImageAlbum === 'function') {

--- a/js/supervisorPackCheckPage.js
+++ b/js/supervisorPackCheckPage.js
@@ -153,6 +153,7 @@ async function loadIndividualOrderForSupervisorCheck(orderKey) {
             urls.forEach((url, idx) => {
                 const img = document.createElement('img');
                 img.src = url;
+                img.alt = `รูปการแพ็ค ${idx + 1}`;
                 img.classList.add('lightbox-thumb');
                 img.addEventListener('click', () => {
                     if (typeof window.showImageAlbum === 'function') {

--- a/js/utils.js
+++ b/js/utils.js
@@ -392,11 +392,12 @@ export function initializeImageLightbox() {
             albumIndex = thumbs.indexOf(target);
             if (sliderElem) {
                 sliderElem.innerHTML = '';
-                albumUrls.forEach(url => {
+                albumUrls.forEach((url, slideIdx) => {
                     const slide = document.createElement('div');
                     slide.className = 'lightbox-slide';
                     const img = document.createElement('img');
                     img.src = url;
+                    img.alt = `รูปภาพ ${slideIdx + 1}`;
                     slide.appendChild(img);
                     sliderElem.appendChild(slide);
                 });
@@ -415,11 +416,12 @@ export function showImageAlbum(urls, startIndex = 0) {
     const sliderElem = document.getElementById('lightboxSlider');
     if (!overlay || !sliderElem || albumUrls.length === 0) return;
     sliderElem.innerHTML = '';
-    albumUrls.forEach(url => {
+    albumUrls.forEach((url, slideIdx) => {
         const slide = document.createElement('div');
         slide.className = 'lightbox-slide';
         const img = document.createElement('img');
         img.src = url;
+        img.alt = `รูปภาพ ${slideIdx + 1}`;
         slide.appendChild(img);
         sliderElem.appendChild(slide);
     });


### PR DESCRIPTION
## Summary
- assign `alt` attributes on dynamically created `<img>` elements

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684eefff6d488324809d3fe5bcdb52ee