### PR TITLE
Clarify mobile photo input usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Dragon Delivery App is a web-based logistics management tool built with Firebase
 - Dashboard with statistics rendered via Chart.js
 - Tracking and packing pages for daily operations
 - Uploaded photos are automatically resized so the longest side is 500&nbsp;px to speed up uploads
+- When packing items on a mobile browser, the photo picker lets users choose an existing image or open the camera. Add `capture="environment"` to the file input in `delivery.html` to launch the camera immediately if desired.
 
 ## Getting Started
 

--- a/delivery.html
+++ b/delivery.html
@@ -204,6 +204,8 @@
                 <h3>Checklist รายการสินค้า:</h3>
                 <ul id="packOrderItemList" class="item-checklist packing-checklist"></ul>
                 <label for="packingPhoto">ถ่ายหรือเลือกรูปสินค้าที่เตรียม:</label>
+                <!-- Mobile users can select from gallery or take a new photo.
+                     Add capture="environment" if you want to open the back camera directly. -->
                 <input type="file" id="packingPhoto" accept="image/*" multiple>
                 <div id="packingPhotoPreviewContainer" class="hidden" style="display:flex; gap:10px; flex-wrap:wrap;"></div>
                 <label for="operatorPackNotes">หมายเหตุ (ถ้ามี):</label>


### PR DESCRIPTION
## Summary
- mention that mobile upload field can use gallery or camera
- add note on using `capture="environment"`
- document this feature in the packing page

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_684ef00180708324b1f691ce1e905f88