### PR TITLE
Implement order notes editing and display

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -339,3 +339,14 @@ tbody tr:hover { background-color: #f1f8ff; }
 .batch-heading { margin:0; cursor:pointer; display:flex; align-items:center; justify-content:space-between; }
 .batch-details { margin-top:10px; }
 
+/* Highlight style for order notes */
+.order-note {
+    background-color: #fff5b1;
+    color: #c0392b;
+    padding: 4px 6px;
+    border-radius: 6px;
+    font-weight: bold;
+    display: inline-block;
+    margin: 4px 0;
+}
+

--- a/delivery.html
+++ b/delivery.html
@@ -205,7 +205,7 @@
                 <h2>แพ็กสินค้า (Package Code: <span id="currentOrderIdForPacking"></span>)</h2>
                 <p><strong>Platform:</strong> <span id="packOrderPlatform"></span></p>
                 <p><strong>Due Date:</strong> <span id="packOrderDueDate"></span></p>
-                <p><strong>หมายเหตุออเดอร์:</strong> <span id="packOrderNotesDisplay"></span></p>
+                <p class="order-note"><strong>หมายเหตุออเดอร์:</strong> <span id="packOrderNotesDisplay"></span></p>
                 <h3>Checklist รายการสินค้า:</h3>
                 <ul id="packOrderItemList" class="item-checklist packing-checklist"></ul>
                 <label for="packingPhoto">ถ่ายหรือเลือกรูปสินค้าที่เตรียม:</label>
@@ -220,7 +220,7 @@
                     <h4>ผลการตรวจสอบโดย Supervisor:</h4>
                     <p>สถานะ: <span id="packCheckStatus"></span></p>
                     <p>ผู้ตรวจ: <span id="packCheckSupervisor"></span></p>
-                    <p>หมายเหตุ: <span id="packCheckNotes"></span></p>
+                    <p class="order-note">หมายเหตุ: <span id="packCheckNotes"></span></p>
                 </div>
             </div>
 
@@ -338,8 +338,8 @@
                 <div style="margin-top:20px;">
                     <h3>รูปภาพจาก Operator:</h3>
                     <div id="checkOrderPackingPhotoContainer" class="photo-preview-container"></div>
-                    <p><strong>หมายเหตุออเดอร์:</strong> <span id="checkOrderOrderNotesDisplay"></span></p>
-                    <p><strong>หมายเหตุจาก Operator:</strong> <span id="checkOrderOperatorNotesDisplay"></span></p>
+                    <p class="order-note"><strong>หมายเหตุออเดอร์:</strong> <span id="checkOrderOrderNotesDisplay"></span></p>
+                    <p class="order-note"><strong>หมายเหตุจาก Operator:</strong> <span id="checkOrderOperatorNotesDisplay"></span></p>
                 </div>
                 <div style="margin-top:20px;">
                     <h3>การดำเนินการตรวจสอบ:</h3>

--- a/delivery.html
+++ b/delivery.html
@@ -195,6 +195,8 @@
                 <button id="addItemToOrderButton" type="button">เพิ่มสินค้าในรายการ</button>
                 <h3>รายการสินค้าที่เพิ่มแล้ว:</h3>
                 <ul id="itemListCurrentOrder" class="item-checklist"></ul>
+                <label for="adminItemsNotes">หมายเหตุออเดอร์:</label>
+                <textarea id="adminItemsNotes"></textarea>
                 <button id="confirmAllItemsButton" type="button">ยืนยันรายการสินค้าทั้งหมด</button>
             </div>
             
@@ -203,6 +205,7 @@
                 <h2>แพ็กสินค้า (Package Code: <span id="currentOrderIdForPacking"></span>)</h2>
                 <p><strong>Platform:</strong> <span id="packOrderPlatform"></span></p>
                 <p><strong>Due Date:</strong> <span id="packOrderDueDate"></span></p>
+                <p><strong>หมายเหตุออเดอร์:</strong> <span id="packOrderNotesDisplay"></span></p>
                 <h3>Checklist รายการสินค้า:</h3>
                 <ul id="packOrderItemList" class="item-checklist packing-checklist"></ul>
                 <label for="packingPhoto">ถ่ายหรือเลือกรูปสินค้าที่เตรียม:</label>
@@ -335,6 +338,7 @@
                 <div style="margin-top:20px;">
                     <h3>รูปภาพจาก Operator:</h3>
                     <div id="checkOrderPackingPhotoContainer" class="photo-preview-container"></div>
+                    <p><strong>หมายเหตุออเดอร์:</strong> <span id="checkOrderOrderNotesDisplay"></span></p>
                     <p><strong>หมายเหตุจาก Operator:</strong> <span id="checkOrderOperatorNotesDisplay"></span></p>
                 </div>
                 <div style="margin-top:20px;">

--- a/js/adminItemsPage.js
+++ b/js/adminItemsPage.js
@@ -11,6 +11,7 @@ let adminItemsAppStatus,
     adminItemsQuantityInput,
     adminItemsUnitInput,
     adminItemsItemListUL,
+    adminItemsNotesInput,
     adminItemsAddItemButton,
     adminItemsConfirmButton;
 
@@ -23,6 +24,7 @@ export function initializeAdminItemsPageListeners() {
     adminItemsQuantityInput = document.getElementById('quantity');
     adminItemsUnitInput = document.getElementById('unit');
     adminItemsItemListUL = document.getElementById('itemListCurrentOrder');
+    adminItemsNotesInput = document.getElementById('adminItemsNotes');
     adminItemsAddItemButton = document.getElementById('addItemToOrderButton');
     adminItemsConfirmButton = document.getElementById('confirmAllItemsButton');
 
@@ -63,6 +65,7 @@ export async function loadOrderForAddingItems(orderKey) {
         if (snap.exists()) {
             const data = snap.val();
             if (adminItemsCurrentOrderIdSpan) adminItemsCurrentOrderIdSpan.textContent = data.packageCode || orderKey;
+            if (adminItemsNotesInput) adminItemsNotesInput.value = data.notes || '';
             if (data.items) {
                 Object.keys(data.items).forEach(id => {
                     renderItemInList(id, data.items[id]);
@@ -123,9 +126,11 @@ async function confirmAllItems() {
         return;
     }
     try {
+        const notesText = adminItemsNotesInput ? adminItemsNotesInput.value.trim() : '';
         await update(ref(database, 'orders/' + currentOrderKeyForItems), {
             status: 'Ready to Pack',
-            lastUpdatedAt: serverTimestamp()
+            lastUpdatedAt: serverTimestamp(),
+            notes: notesText || null
         });
         showAppStatus('ยืนยันรายการสินค้าแล้ว', 'success', adminItemsAppStatus);
         currentOrderKeyForItems = null;

--- a/js/adminParcelDetailPage.js
+++ b/js/adminParcelDetailPage.js
@@ -39,7 +39,7 @@ export async function loadParcelDetail(orderKey) {
                 <p><strong>สถานะ:</strong> ${translateStatusToThai(data.status, !!data.shipmentInfo?.adminVerifiedBy)}</p>
                 <p><strong>Created:</strong> ${formatDateTimeDDMMYYYYHHMM(data.createdAt)}</p>
                 <p><strong>Due Date:</strong> ${formatDateDDMMYYYY(data.dueDate)}</p>
-                <p><strong>หมายเหตุ:</strong> ${data.notes || '-'}</p>
+                <p class="order-note"><strong>หมายเหตุ:</strong> ${data.notes || '-'}</p>
             `;
             if (data.items) {
                 html += '<h3>รายการสินค้า:</h3><ul>';

--- a/js/adminParcelDetailPage.js
+++ b/js/adminParcelDetailPage.js
@@ -39,6 +39,7 @@ export async function loadParcelDetail(orderKey) {
                 <p><strong>สถานะ:</strong> ${translateStatusToThai(data.status, !!data.shipmentInfo?.adminVerifiedBy)}</p>
                 <p><strong>Created:</strong> ${formatDateTimeDDMMYYYYHHMM(data.createdAt)}</p>
                 <p><strong>Due Date:</strong> ${formatDateDDMMYYYY(data.dueDate)}</p>
+                <p><strong>หมายเหตุ:</strong> ${data.notes || '-'}</p>
             `;
             if (data.items) {
                 html += '<h3>รายการสินค้า:</h3><ul>';

--- a/js/operatorPackingPage.js
+++ b/js/operatorPackingPage.js
@@ -13,7 +13,7 @@ let existingPackingPhotoUrls = [];
 
 // DOM Elements for this page - to be initialized
 let opPacking_pageElement, opPacking_currentOrderIdSpan, opPacking_platformSpan, opPacking_dueDateSpan,
-    opPacking_itemListUL, opPacking_photoInput, opPacking_photoPreviewContainer,
+    opPacking_itemListUL, opPacking_photoInput, opPacking_photoPreviewContainer, opPacking_orderNotesSpan,
     opPacking_notesTextarea, opPacking_confirmButton, opPacking_supervisorCheckResultDiv,
     opPacking_packCheckStatusSpan, opPacking_packCheckSupervisorSpan, opPacking_packCheckNotesSpan,
     opPacking_appStatus;
@@ -27,6 +27,7 @@ export function initializeOperatorPackingPageListeners() {
     opPacking_itemListUL = document.getElementById('packOrderItemList');
     opPacking_photoInput = document.getElementById('packingPhoto');
     opPacking_photoPreviewContainer = document.getElementById('packingPhotoPreviewContainer');
+    opPacking_orderNotesSpan = document.getElementById('packOrderNotesDisplay');
     opPacking_notesTextarea = document.getElementById('operatorPackNotes');
     opPacking_confirmButton = document.getElementById('confirmPackingButton');
     opPacking_supervisorCheckResultDiv = document.getElementById('supervisorPackCheckResult');
@@ -85,6 +86,7 @@ export async function loadOrderForPacking(orderKey) {
             if(opPacking_currentOrderIdSpan) opPacking_currentOrderIdSpan.textContent = currentOrderPackageCode;
             if(opPacking_platformSpan) opPacking_platformSpan.textContent = orderData.platform || 'N/A';
             if(opPacking_dueDateSpan) opPacking_dueDateSpan.textContent = formatDateDDMMYYYY(orderData.dueDate);
+            if(opPacking_orderNotesSpan) opPacking_orderNotesSpan.textContent = orderData.notes || '-';
             
             if(opPacking_itemListUL) opPacking_itemListUL.innerHTML = '';
             if (orderData.items) {

--- a/js/operatorTasksPage.js
+++ b/js/operatorTasksPage.js
@@ -91,7 +91,7 @@ export async function loadOperatorPendingTasks() {
                     <h4 style="margin-top:0; margin-bottom:8px;">Package Code: ${orderData.packageCode || 'N/A'}</h4>
                     <p style="font-size:0.9em; margin:3px 0;"><strong>Platform:</strong> ${orderData.platform || 'N/A'}</p>
                     <p style="font-size:0.9em; margin:3px 0;"><strong>Due Date:</strong> ${formatDateDDMMYYYY(orderData.dueDate)}</p>
-                    <p style="font-size:0.9em; margin:3px 0;"><strong>หมายเหตุ:</strong> ${orderData.notes || '-'}</p>
+                    <p style="font-size:0.9em; margin:3px 0;" class="order-note"><strong>หมายเหตุ:</strong> ${orderData.notes || '-'}</p>
                     <button type="button" class="start-packing-btn" data-orderkey="${orderKey}" style="width:auto; padding:8px 15px; margin-top:10px; font-size:0.9em;">เริ่มแพ็กรายการนี้</button>
                     ${editBtnHtml}
                     ${deleteBtnHtml}

--- a/js/operatorTasksPage.js
+++ b/js/operatorTasksPage.js
@@ -67,15 +67,7 @@ export async function loadOperatorPendingTasks() {
                 tasksArray.push({ key: childSnapshot.key, ...childSnapshot.val() });
             });
 
-            const now = Date.now();
-            tasksArray.sort((a, b) => {
-                const aOver = a.dueDate <= now;
-                const bOver = b.dueDate <= now;
-                if (aOver && !bOver) return -1;
-                if (!aOver && bOver) return 1;
-                if (a.dueDate !== b.dueDate) return a.dueDate - b.dueDate;
-                return (a.createdAt || 0) - (b.createdAt || 0);
-            });
+            tasksArray.sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0));
 
             tasksArray.forEach(task => {
                 const orderKey = task.key;
@@ -99,6 +91,7 @@ export async function loadOperatorPendingTasks() {
                     <h4 style="margin-top:0; margin-bottom:8px;">Package Code: ${orderData.packageCode || 'N/A'}</h4>
                     <p style="font-size:0.9em; margin:3px 0;"><strong>Platform:</strong> ${orderData.platform || 'N/A'}</p>
                     <p style="font-size:0.9em; margin:3px 0;"><strong>Due Date:</strong> ${formatDateDDMMYYYY(orderData.dueDate)}</p>
+                    <p style="font-size:0.9em; margin:3px 0;"><strong>หมายเหตุ:</strong> ${orderData.notes || '-'}</p>
                     <button type="button" class="start-packing-btn" data-orderkey="${orderKey}" style="width:auto; padding:8px 15px; margin-top:10px; font-size:0.9em;">เริ่มแพ็กรายการนี้</button>
                     ${editBtnHtml}
                     ${deleteBtnHtml}

--- a/js/shippedOrdersPage.js
+++ b/js/shippedOrdersPage.js
@@ -89,7 +89,7 @@ export async function loadShippedOrders() {
                 const checked = o.data.shipmentInfo?.adminVerifiedBy ? 'disabled checked' : '';
                 const cb = `<input type="checkbox" class="admin-verify-checkbox" data-orderkey="${o.key}" ${checked}>`;
                 const detailBtn = `<button type="button" class="shipped-detail-btn" data-orderkey="${o.key}" style="width:auto;padding:4px 8px;font-size:0.8em;margin-left:5px;">ดูรายละเอียด</button>`;
-                html += `<li style="border-bottom:1px solid #eee;padding:5px 0;">${cb} ${o.data.packageCode || o.key} (${o.data.platform || 'N/A'}) ${detailBtn}<br><small>${o.data.notes || ''}</small></li>`;
+                html += `<li style="border-bottom:1px solid #eee;padding:5px 0;">${cb} ${o.data.packageCode || o.key} (${o.data.platform || 'N/A'}) ${detailBtn}<br><small class="order-note">${o.data.notes || ''}</small></li>`;
             });
             html += '</ul></div>';
             div.innerHTML = html;
@@ -166,7 +166,7 @@ async function loadShippedOrderDetail(orderKey) {
             let html = `
                 <p><strong>Platform:</strong> ${data.platform || 'N/A'}</p>
                 <p><strong>ส่งจริงเมื่อ:</strong> ${data.shipmentInfo?.shippedAt_actual ? formatDateTimeDDMMYYYYHHMM(data.shipmentInfo.shippedAt_actual) : '-'}</p>
-                <p><strong>หมายเหตุ:</strong> ${data.notes || '-'}</p>
+                <p class="order-note"><strong>หมายเหตุ:</strong> ${data.notes || '-'}</p>
             `;
             if (role === 'administrator') {
                 html += `<p><strong>Batch ID:</strong> ${data.shipmentInfo?.batchId || '-'}</p>`;

--- a/js/shippedOrdersPage.js
+++ b/js/shippedOrdersPage.js
@@ -89,7 +89,7 @@ export async function loadShippedOrders() {
                 const checked = o.data.shipmentInfo?.adminVerifiedBy ? 'disabled checked' : '';
                 const cb = `<input type="checkbox" class="admin-verify-checkbox" data-orderkey="${o.key}" ${checked}>`;
                 const detailBtn = `<button type="button" class="shipped-detail-btn" data-orderkey="${o.key}" style="width:auto;padding:4px 8px;font-size:0.8em;margin-left:5px;">ดูรายละเอียด</button>`;
-                html += `<li style="border-bottom:1px solid #eee;padding:5px 0;">${cb} ${o.data.packageCode || o.key} (${o.data.platform || 'N/A'}) ${detailBtn}</li>`;
+                html += `<li style="border-bottom:1px solid #eee;padding:5px 0;">${cb} ${o.data.packageCode || o.key} (${o.data.platform || 'N/A'}) ${detailBtn}<br><small>${o.data.notes || ''}</small></li>`;
             });
             html += '</ul></div>';
             div.innerHTML = html;
@@ -166,6 +166,7 @@ async function loadShippedOrderDetail(orderKey) {
             let html = `
                 <p><strong>Platform:</strong> ${data.platform || 'N/A'}</p>
                 <p><strong>ส่งจริงเมื่อ:</strong> ${data.shipmentInfo?.shippedAt_actual ? formatDateTimeDDMMYYYYHHMM(data.shipmentInfo.shippedAt_actual) : '-'}</p>
+                <p><strong>หมายเหตุ:</strong> ${data.notes || '-'}</p>
             `;
             if (role === 'administrator') {
                 html += `<p><strong>Batch ID:</strong> ${data.shipmentInfo?.batchId || '-'}</p>`;

--- a/js/supervisorPackCheckPage.js
+++ b/js/supervisorPackCheckPage.js
@@ -70,6 +70,7 @@ export async function loadOrdersForPackCheck() {
                 orderItemDiv.innerHTML = `
                     <h4 style="margin-top:0; margin-bottom:8px;">Package Code: ${orderData.packageCode || 'N/A'}</h4>
                     <p style="font-size:0.9em; margin:3px 0;"><strong>Platform:</strong> ${orderData.platform || 'N/A'}</p>
+                    <p style="font-size:0.9em; margin:3px 0;"><strong>หมายเหตุ:</strong> ${orderData.notes || '-'}</p>
                     <p style="font-size:0.9em; margin:3px 0;"><strong>Packed by (Operator UID):</strong> ${orderData.packingInfo?.packedBy_operatorUid?.substring(0,8) || 'N/A'}...</p>
                     <button type="button" class="supervisor-check-btn" data-orderkey="${orderKey}" style="width:auto; padding:8px 15px; margin-top:10px; font-size:0.9em;">ตรวจสอบรายการนี้</button>
                     <button type="button" class="return-to-pack-btn" data-orderkey="${orderKey}" style="width:auto; padding:8px 15px; margin-top:10px; margin-left:5px; font-size:0.9em; background-color:#f39c12;">แพ็คใหม่</button>
@@ -162,6 +163,7 @@ async function loadIndividualOrderForSupervisorCheck(orderKey) {
                 });
                 uiElements.checkOrderPackingPhotoContainer.appendChild(img);
             });
+            uiElements.checkOrderOrderNotesDisplay.textContent = orderData.notes || '-';
             uiElements.checkOrderOperatorNotesDisplay.textContent = orderData.packingInfo?.operatorNotes || 'ไม่มีหมายเหตุจาก Operator';
             
             uiElements.supervisorPackCheckNotes.value = ''; // Clear supervisor's previous notes for this new check

--- a/js/supervisorPackCheckPage.js
+++ b/js/supervisorPackCheckPage.js
@@ -70,7 +70,7 @@ export async function loadOrdersForPackCheck() {
                 orderItemDiv.innerHTML = `
                     <h4 style="margin-top:0; margin-bottom:8px;">Package Code: ${orderData.packageCode || 'N/A'}</h4>
                     <p style="font-size:0.9em; margin:3px 0;"><strong>Platform:</strong> ${orderData.platform || 'N/A'}</p>
-                    <p style="font-size:0.9em; margin:3px 0;"><strong>หมายเหตุ:</strong> ${orderData.notes || '-'}</p>
+                    <p style="font-size:0.9em; margin:3px 0;" class="order-note"><strong>หมายเหตุ:</strong> ${orderData.notes || '-'}</p>
                     <p style="font-size:0.9em; margin:3px 0;"><strong>Packed by (Operator UID):</strong> ${orderData.packingInfo?.packedBy_operatorUid?.substring(0,8) || 'N/A'}...</p>
                     <button type="button" class="supervisor-check-btn" data-orderkey="${orderKey}" style="width:auto; padding:8px 15px; margin-top:10px; font-size:0.9em;">ตรวจสอบรายการนี้</button>
                     <button type="button" class="return-to-pack-btn" data-orderkey="${orderKey}" style="width:auto; padding:8px 15px; margin-top:10px; margin-left:5px; font-size:0.9em; background-color:#f39c12;">แพ็คใหม่</button>

--- a/js/ui.js
+++ b/js/ui.js
@@ -73,6 +73,7 @@ export function initializeCoreDOMElements() { // Renamed for clarity
     uiElements.checkOrderPlatformDisplay = document.getElementById('checkOrderPlatformDisplay');
     uiElements.checkOrderItemListDisplay = document.getElementById('checkOrderItemListDisplay');
     uiElements.checkOrderPackingPhotoContainer = document.getElementById('checkOrderPackingPhotoContainer');
+    uiElements.checkOrderOrderNotesDisplay = document.getElementById('checkOrderOrderNotesDisplay');
     uiElements.checkOrderOperatorNotesDisplay = document.getElementById('checkOrderOperatorNotesDisplay');
     uiElements.supervisorPackCheckNotes = document.getElementById('supervisorPackCheckNotes');
 


### PR DESCRIPTION
## Summary
- allow admins to edit order notes when modifying items
- show order notes on packing page and supervisor check pages
- display notes throughout lists, detail pages and shipped orders
- sort packing tasks by creation time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f90ec44788324a0a2e1824ec9ba76