### PR TITLE
Show package info when shipping

### DIFF
--- a/delivery.html
+++ b/delivery.html
@@ -294,9 +294,19 @@
                         <button id="stopScanForBatchButton" type="button" class="secondary hidden" style="margin-top:5px;">หยุดสแกน</button>
                     </div>
                     <h4>รายการพัสดุในรอบส่งนี้: (<span id="batchItemCount">0</span> ชิ้น)</h4>
-                    <ul id="batchItemList" class="item-checklist" style="max-height:200px; overflow-y:auto; border:1px solid #eee; padding:10px;">
-                        <!-- พัสดุที่สแกนแล้วจะแสดงที่นี่ -->
-                    </ul>
+                    <div id="batchItemsTableContainer" style="max-height:200px; overflow-y:auto; border:1px solid #eee; padding:10px;">
+                        <table id="batchItemsTable" style="width:100%; border-collapse:collapse;">
+                            <thead>
+                                <tr style="background-color:#f8f9fa;">
+                                    <th>Package Code</th>
+                                    <th>หมายเหตุ</th>
+                                    <th>รายละเอียดสินค้า</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
                     <button id="confirmBatchAndProceedButton" type="button" style="margin-top:15px;">ยืนยันรอบส่งและไปถ่ายรูป</button>
                 </div>
             </div>
@@ -308,6 +318,18 @@
                 <p><strong>Batch ID:</strong> <span id="confirmShipBatchIdDisplay"></span></p>
                 <p><strong>Courier:</strong> <span id="confirmShipCourierDisplay"></span></p>
                 <p><strong>จำนวนพัสดุ:</strong> <span id="confirmShipItemCountDisplay"></span> รายการ</p>
+                <div id="confirmPackagesTableContainer" style="max-height:200px; overflow-y:auto; border:1px solid #eee; padding:10px; margin-top:10px;">
+                    <table id="confirmPackagesTable" style="width:100%; border-collapse:collapse;">
+                        <thead>
+                            <tr style="background-color:#f8f9fa;">
+                                <th>Package Code</th>
+                                <th>หมายเหตุ</th>
+                                <th>รายละเอียดสินค้า</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
                 <div class="form-group">
                     <label for="shipmentGroupPhoto">ถ่ายหรือเลือกรูปรวมพัสดุที่ส่ง:</label>
                     <input type="file" id="shipmentGroupPhoto" accept="image/*" >

--- a/js/operatorShippingPage.js
+++ b/js/operatorShippingPage.js
@@ -8,7 +8,7 @@ import { getCurrentUser, getCurrentUserRole } from './auth.js';
 
 let currentActiveBatchId = null; // Stores the ID of the batch currently being worked on
 let currentBatchCourier = '';
-let itemsInCurrentBatch = {}; // Stores { orderKey: packageCode } for the current batch
+let itemsInCurrentBatch = {}; // Stores { orderKey: {packageCode, notes, items[]} }
 let shipmentGroupPhotoFile = null; // Stores the selected group photo file for shipment
 let readyToShipPackages = []; // Array of {orderKey, packageCode, platform}
 let filteredReadyPackages = [];
@@ -75,7 +75,7 @@ export function setupShippingBatchPage() {
         renderBatchItems(); // Re-render items if a batch is already active
     } else {
         if (uiElements.currentBatchIdDisplay) uiElements.currentBatchIdDisplay.textContent = 'N/A';
-        if (uiElements.batchItemList) uiElements.batchItemList.innerHTML = '<li>ยังไม่มีพัสดุในรอบส่งนี้</li>';
+        if (uiElements.batchItemsTableBody) uiElements.batchItemsTableBody.innerHTML = '<tr><td colspan="4" style="text-align:center;">ยังไม่มีพัสดุในรอบส่งนี้</td></tr>';
         if (uiElements.batchItemCount) uiElements.batchItemCount.textContent = '0';
     }
     if (uiElements.courierSelect) uiElements.courierSelect.value = "";
@@ -186,7 +186,11 @@ function startScanForBatch() {
                 if (itemsInCurrentBatch[orderKeyFound]) {
                     showAppStatus(`พัสดุ ${packageCodeScanned} อยู่ใน Batch นี้แล้ว`, 'info', uiElements.appStatus);
                 } else {
-                    itemsInCurrentBatch[orderKeyFound] = packageCodeScanned; // Store package code for display
+                    itemsInCurrentBatch[orderKeyFound] = {
+                        packageCode: packageCodeScanned,
+                        notes: orderDataFound.notes || '',
+                        items: orderDataFound.items ? Object.values(orderDataFound.items).map(i => `${i.productName} - ${i.quantity} ${i.unit}`).join(', ') : ''
+                    };
                     renderBatchItems();
                     showAppStatus(`เพิ่ม ${packageCodeScanned} เข้า Batch สำเร็จ`, 'success', uiElements.appStatus);
                 }
@@ -259,7 +263,8 @@ async function loadReadyToShipPackages() {
                             orderKey: child.key,
                             packageCode: pkg,
                             platform: child.val().platform || 'Other',
-                            notes: child.val().notes || ''
+                            notes: child.val().notes || '',
+                            items: child.val().items ? Object.values(child.val().items).map(i => `${i.productName} - ${i.quantity} ${i.unit}`).join(', ') : ''
                         });
                     }
                 });
@@ -281,7 +286,11 @@ function addPackageCodeManually(packageCode) {
         showAppStatus(`พัสดุ ${packageCode} อยู่ในรอบส่งนี้แล้ว`, 'info', uiElements.appStatus);
         return;
     }
-    itemsInCurrentBatch[entry.orderKey] = packageCode;
+    itemsInCurrentBatch[entry.orderKey] = {
+        packageCode: entry.packageCode,
+        notes: entry.notes,
+        items: entry.items
+    };
     if (uiElements.readyToShipCheckboxList) {
         const cb = uiElements.readyToShipCheckboxList.querySelector(`input[data-orderkey="${entry.orderKey}"]`);
         if (cb) cb.checked = true;
@@ -291,15 +300,15 @@ function addPackageCodeManually(packageCode) {
 }
 
 function removePackageFromBatch(orderKey) {
-    const code = itemsInCurrentBatch[orderKey];
-    if (!code) return;
+    const entry = itemsInCurrentBatch[orderKey];
+    if (!entry) return;
     delete itemsInCurrentBatch[orderKey];
     if (uiElements.readyToShipCheckboxList) {
         const cb = uiElements.readyToShipCheckboxList.querySelector(`input[data-orderkey="${orderKey}"]`);
         if (cb) cb.checked = false;
     }
     renderBatchItems();
-    showAppStatus(`ลบ ${code} ออกจากรอบส่ง`, 'info', uiElements.appStatus);
+    showAppStatus(`ลบ ${entry.packageCode} ออกจากรอบส่ง`, 'info', uiElements.appStatus);
 }
 
 function getPlatformFilter(value) {
@@ -362,25 +371,35 @@ function selectAllFilteredPackages() {
 }
 
 function renderBatchItems() {
-    if (!uiElements.batchItemList || !uiElements.batchItemCount) return;
-    uiElements.batchItemList.innerHTML = '';
+    if (!uiElements.batchItemsTableBody || !uiElements.batchItemCount) return;
+    uiElements.batchItemsTableBody.innerHTML = '';
     const itemCount = Object.keys(itemsInCurrentBatch).length;
     uiElements.batchItemCount.textContent = itemCount;
 
     if (itemCount === 0) {
-        uiElements.batchItemList.innerHTML = '<li>ยังไม่มีพัสดุในรอบส่งนี้</li>';
+        uiElements.batchItemsTableBody.innerHTML = '<tr><td colspan="4" style="text-align:center;">ยังไม่มีพัสดุในรอบส่งนี้</td></tr>';
         return;
     }
     for (const orderKey in itemsInCurrentBatch) {
-        const packageCode = itemsInCurrentBatch[orderKey];
-        const li = document.createElement('li');
-        li.textContent = packageCode;
+        const entry = itemsInCurrentBatch[orderKey];
+        const tr = document.createElement('tr');
+        const codeTd = document.createElement('td');
+        codeTd.textContent = entry.packageCode;
+        tr.appendChild(codeTd);
+        const noteTd = document.createElement('td');
+        noteTd.innerHTML = entry.notes ? `<span class="order-note">${entry.notes}</span>` : '';
+        tr.appendChild(noteTd);
+        const itemsTd = document.createElement('td');
+        itemsTd.textContent = entry.items || '';
+        tr.appendChild(itemsTd);
+        const removeTd = document.createElement('td');
         const btn = document.createElement('button');
         btn.textContent = '✖';
         btn.className = 'remove-batch-item-btn';
         btn.addEventListener('click', () => removePackageFromBatch(orderKey));
-        li.appendChild(btn);
-        uiElements.batchItemList.appendChild(li);
+        removeTd.appendChild(btn);
+        tr.appendChild(removeTd);
+        uiElements.batchItemsTableBody.appendChild(tr);
     }
 }
 
@@ -400,6 +419,16 @@ function confirmBatchAndMoveToPhoto() {
     if(uiElements.confirmShipCourierDisplay) uiElements.confirmShipCourierDisplay.textContent = currentBatchCourier;
     if(uiElements.confirmShipItemCountDisplay) uiElements.confirmShipItemCountDisplay.textContent = Object.keys(itemsInCurrentBatch).length;
     
+    if(uiElements.confirmPackagesTableBody){
+        uiElements.confirmPackagesTableBody.innerHTML = '';
+        for(const orderKey in itemsInCurrentBatch){
+            const entry = itemsInCurrentBatch[orderKey];
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td>${entry.packageCode}</td><td>${entry.notes ? `<span class="order-note">${entry.notes}</span>` : ''}</td><td>${entry.items || ''}</td>`;
+            uiElements.confirmPackagesTableBody.appendChild(tr);
+        }
+    }
+
     if(uiElements.shipmentGroupPhoto) uiElements.shipmentGroupPhoto.value = ''; // Reset file input
     if(uiElements.shipmentGroupPhotoPreview) {
         uiElements.shipmentGroupPhotoPreview.classList.add('hidden');

--- a/js/ui.js
+++ b/js/ui.js
@@ -52,8 +52,9 @@ export function initializeCoreDOMElements() { // Renamed for clarity
     uiElements.readyToShipCheckboxList = document.getElementById('readyToShipCheckboxList');
     uiElements.selectAllReadyPackagesButton = document.getElementById('selectAllReadyPackagesButton');
     uiElements.currentBatchIdDisplay = document.getElementById('currentBatchIdDisplay');
-    uiElements.batchItemList = document.getElementById('batchItemList');
+    uiElements.batchItemsTableBody = document.querySelector('#batchItemsTable tbody');
     uiElements.batchItemCount = document.getElementById('batchItemCount');
+    uiElements.batchItemList = document.getElementById('batchItemList'); // legacy
     uiElements.qrScanner_Batch_div = document.getElementById('qrScanner_Batch');
     uiElements.qrScannerContainer_Batch = document.getElementById('qrScannerContainer_Batch');
     uiElements.confirmShipBatchIdDisplay = document.getElementById('confirmShipBatchIdDisplay');
@@ -63,6 +64,7 @@ export function initializeCoreDOMElements() { // Renamed for clarity
     uiElements.shipmentGroupPhotoPreview = document.getElementById('shipmentGroupPhotoPreview');
     uiElements.shipmentGpsLocationDisplay = document.getElementById('shipmentGpsLocationDisplay');
     uiElements.finalizeShipmentButton = document.getElementById('finalizeShipmentButton');
+    uiElements.confirmPackagesTableBody = document.querySelector('#confirmPackagesTable tbody');
 
     uiElements.refreshSupervisorPackCheckList = document.getElementById('refreshSupervisorPackCheckList');
     uiElements.packCheckListContainer = document.getElementById('packCheckListContainer');


### PR DESCRIPTION
## Summary
- show selected packages in a table on the shipping page
- display the same table when confirming shipments
- store package notes and items for each batch entry
- expose new DOM elements for tables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fbf5bc5388324b15b62e9da91ba4a