### PR TITLE
Add back navigation on shipment confirmation page

### DIFF
--- a/delivery.html
+++ b/delivery.html
@@ -318,6 +318,7 @@
                     <p id="shipmentGpsLocationDisplay" style="font-size:0.9em; color:#555;">กำลังดึงข้อมูล...</p>
                     <button id="getGpsButton" type="button" class="secondary" style="width:auto;">ดึง GPS ปัจจุบัน</button>
                 </div>
+                <button id="backToShippingBatchButton" type="button" class="secondary" style="width:auto; margin-top:10px; margin-right:10px;">กลับไปแก้ไข</button>
                 <button id="finalizeShipmentButton" type="button">ยืนยันการจัดส่งรอบนี้</button>
             </div>
             <!-- ***** สิ้นสุดหน้า Operator Confirm Shipment ***** -->

--- a/delivery.html
+++ b/delivery.html
@@ -294,9 +294,19 @@
                         <button id="stopScanForBatchButton" type="button" class="secondary hidden" style="margin-top:5px;">หยุดสแกน</button>
                     </div>
                     <h4>รายการพัสดุในรอบส่งนี้: (<span id="batchItemCount">0</span> ชิ้น)</h4>
-                    <ul id="batchItemList" class="item-checklist" style="max-height:200px; overflow-y:auto; border:1px solid #eee; padding:10px;">
-                        <!-- พัสดุที่สแกนแล้วจะแสดงที่นี่ -->
-                    </ul>
+                    <div id="batchItemsTableContainer" style="max-height:200px; overflow-y:auto; border:1px solid #eee; padding:10px;">
+                        <table id="batchItemsTable" style="width:100%; border-collapse:collapse;">
+                            <thead>
+                                <tr style="background-color:#f8f9fa;">
+                                    <th>Package Code</th>
+                                    <th>หมายเหตุ</th>
+                                    <th>รายละเอียดสินค้า</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
                     <button id="confirmBatchAndProceedButton" type="button" style="margin-top:15px;">ยืนยันรอบส่งและไปถ่ายรูป</button>
                 </div>
             </div>
@@ -308,6 +318,18 @@
                 <p><strong>Batch ID:</strong> <span id="confirmShipBatchIdDisplay"></span></p>
                 <p><strong>Courier:</strong> <span id="confirmShipCourierDisplay"></span></p>
                 <p><strong>จำนวนพัสดุ:</strong> <span id="confirmShipItemCountDisplay"></span> รายการ</p>
+                <div id="confirmPackagesTableContainer" style="max-height:200px; overflow-y:auto; border:1px solid #eee; padding:10px; margin-top:10px;">
+                    <table id="confirmPackagesTable" style="width:100%; border-collapse:collapse;">
+                        <thead>
+                            <tr style="background-color:#f8f9fa;">
+                                <th>Package Code</th>
+                                <th>หมายเหตุ</th>
+                                <th>รายละเอียดสินค้า</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
                 <div class="form-group">
                     <label for="shipmentGroupPhoto">ถ่ายหรือเลือกรูปรวมพัสดุที่ส่ง:</label>
                     <input type="file" id="shipmentGroupPhoto" accept="image/*" >

--- a/js/operatorShippingPage.js
+++ b/js/operatorShippingPage.js
@@ -12,6 +12,7 @@ let itemsInCurrentBatch = {}; // Stores { orderKey: packageCode } for the curren
 let shipmentGroupPhotoFile = null; // Stores the selected group photo file for shipment
 let readyToShipPackages = []; // Array of {orderKey, packageCode, platform}
 let filteredReadyPackages = [];
+let preserveBatchStateForReturn = false;
 
 export function initializeOperatorShippingPageListeners() {
     if (!uiElements.createNewBatchButton || !uiElements.startScanForBatchButton || 
@@ -64,7 +65,10 @@ export function initializeOperatorShippingPageListeners() {
     uiElements.shipmentGroupPhoto.addEventListener('change', handleShipmentGroupPhotoSelect);
     uiElements.finalizeShipmentButton.addEventListener('click', finalizeShipment);
     if (uiElements.backToShippingBatchButton) {
-        uiElements.backToShippingBatchButton.addEventListener('click', () => showPage('operatorShippingBatchPage'));
+        uiElements.backToShippingBatchButton.addEventListener('click', () => {
+            preserveBatchStateForReturn = true;
+            showPage('operatorShippingBatchPage');
+        });
     }
 
     updateBatchIdVisibilityForRole();
@@ -81,12 +85,21 @@ export function setupShippingBatchPage() {
         if (uiElements.batchItemList) uiElements.batchItemList.innerHTML = '<li>ยังไม่มีพัสดุในรอบส่งนี้</li>';
         if (uiElements.batchItemCount) uiElements.batchItemCount.textContent = '0';
     }
-    if (uiElements.courierSelect) uiElements.courierSelect.value = "";
-    if (uiElements.otherCourierInput) {
-        uiElements.otherCourierInput.value = "";
-        uiElements.otherCourierInput.classList.add('hidden');
+    if (preserveBatchStateForReturn && currentActiveBatchId) {
+        if (uiElements.courierSelect) uiElements.courierSelect.value = currentBatchCourier || '';
+        if (uiElements.otherCourierInput) {
+            uiElements.otherCourierInput.value = uiElements.courierSelect.value === 'Other' ? currentBatchCourier : '';
+            uiElements.otherCourierInput.classList.toggle('hidden', uiElements.courierSelect.value !== 'Other');
+        }
+    } else {
+        if (uiElements.courierSelect) uiElements.courierSelect.value = "";
+        if (uiElements.otherCourierInput) {
+            uiElements.otherCourierInput.value = "";
+            uiElements.otherCourierInput.classList.add('hidden');
+        }
+        currentBatchCourier = '';
     }
-    currentBatchCourier = '';
+    preserveBatchStateForReturn = false;
     loadReadyToShipPackages();
     showAppStatus("พร้อมสำหรับการจัดการรอบส่ง", "info", uiElements.appStatus);
 }

--- a/js/operatorShippingPage.js
+++ b/js/operatorShippingPage.js
@@ -63,6 +63,9 @@ export function initializeOperatorShippingPageListeners() {
     
     uiElements.shipmentGroupPhoto.addEventListener('change', handleShipmentGroupPhotoSelect);
     uiElements.finalizeShipmentButton.addEventListener('click', finalizeShipment);
+    if (uiElements.backToShippingBatchButton) {
+        uiElements.backToShippingBatchButton.addEventListener('click', () => showPage('operatorShippingBatchPage'));
+    }
 
     updateBatchIdVisibilityForRole();
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -63,6 +63,7 @@ export function initializeCoreDOMElements() { // Renamed for clarity
     uiElements.shipmentGroupPhotoPreview = document.getElementById('shipmentGroupPhotoPreview');
     uiElements.shipmentGpsLocationDisplay = document.getElementById('shipmentGpsLocationDisplay');
     uiElements.finalizeShipmentButton = document.getElementById('finalizeShipmentButton');
+    uiElements.backToShippingBatchButton = document.getElementById('backToShippingBatchButton');
 
     uiElements.refreshSupervisorPackCheckList = document.getElementById('refreshSupervisorPackCheckList');
     uiElements.packCheckListContainer = document.getElementById('packCheckListContainer');

--- a/js/ui.js
+++ b/js/ui.js
@@ -54,7 +54,6 @@ export function initializeCoreDOMElements() { // Renamed for clarity
     uiElements.currentBatchIdDisplay = document.getElementById('currentBatchIdDisplay');
     uiElements.batchItemsTableBody = document.querySelector('#batchItemsTable tbody');
     uiElements.batchItemCount = document.getElementById('batchItemCount');
-    uiElements.batchItemList = document.getElementById('batchItemList'); // legacy
     uiElements.qrScanner_Batch_div = document.getElementById('qrScanner_Batch');
     uiElements.qrScannerContainer_Batch = document.getElementById('qrScannerContainer_Batch');
     uiElements.confirmShipBatchIdDisplay = document.getElementById('confirmShipBatchIdDisplay');

--- a/js/ui.js
+++ b/js/ui.js
@@ -52,8 +52,9 @@ export function initializeCoreDOMElements() { // Renamed for clarity
     uiElements.readyToShipCheckboxList = document.getElementById('readyToShipCheckboxList');
     uiElements.selectAllReadyPackagesButton = document.getElementById('selectAllReadyPackagesButton');
     uiElements.currentBatchIdDisplay = document.getElementById('currentBatchIdDisplay');
-    uiElements.batchItemList = document.getElementById('batchItemList');
+    uiElements.batchItemsTableBody = document.querySelector('#batchItemsTable tbody');
     uiElements.batchItemCount = document.getElementById('batchItemCount');
+    uiElements.batchItemList = document.getElementById('batchItemList'); // legacy
     uiElements.qrScanner_Batch_div = document.getElementById('qrScanner_Batch');
     uiElements.qrScannerContainer_Batch = document.getElementById('qrScannerContainer_Batch');
     uiElements.confirmShipBatchIdDisplay = document.getElementById('confirmShipBatchIdDisplay');
@@ -64,6 +65,7 @@ export function initializeCoreDOMElements() { // Renamed for clarity
     uiElements.shipmentGpsLocationDisplay = document.getElementById('shipmentGpsLocationDisplay');
     uiElements.finalizeShipmentButton = document.getElementById('finalizeShipmentButton');
     uiElements.backToShippingBatchButton = document.getElementById('backToShippingBatchButton');
+    uiElements.confirmPackagesTableBody = document.querySelector('#confirmPackagesTable tbody');
 
     uiElements.refreshSupervisorPackCheckList = document.getElementById('refreshSupervisorPackCheckList');
     uiElements.packCheckListContainer = document.getElementById('packCheckListContainer');


### PR DESCRIPTION
## Summary
- add a back button to return from the confirmation screen
- wire up DOM reference in `ui.js`
- handle click in `operatorShippingPage.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fbf7c31a08324b1f52b9ccb3aebae